### PR TITLE
CSS-4676: Add tests and CI/CD workflows

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,27 @@
+name: Integration tests
+
+on:
+  pull_request:
+
+jobs:
+  integration-test-microk8s:
+    name: Integration tests (microk8s)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.1/stable
+          provider: microk8s
+          channel: 1.25-strict/stable
+      - name: Run integration tests
+        # set a predictable model name so it can be consumed by charm-logdump-action
+        run: tox -e integration -- --model testing
+      - name: Dump logs
+        uses: canonical/charm-logdump-action@main
+        if: failure()
+        with:
+          app: temporal-worker-k8s
+          model: testing

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -1,0 +1,26 @@
+name: Promote charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      origin-channel:
+        type: choice
+        description: 'Origin Channel'
+        options:
+        - latest/edge
+      destination-channel:
+        type: choice
+        description: 'Destination Channel'
+        options:
+        - latest/stable
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  promote-charm:
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    with:
+      origin-channel: ${{ github.event.inputs.origin-channel }}
+      destination-channel: ${{ github.event.inputs.destination-channel }}
+    secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,9 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  unit-tests:
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    secrets: inherit

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -1,0 +1,23 @@
+name: Publish to edge
+
+# On push to a "special" branch, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+# where a "special" branch is one of main/master or track/**, as
+# by convention these branches are the source for a corresponding
+# charmhub edge channel.
+
+on:
+  push:
+    branches:
+      - main
+      - track/**
+
+jobs:
+  publish-to-edge:
+    uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    secrets: inherit
+    with:
+      integration-test-provider: microk8s
+      integration-test-provider-channel: 1.25-strict/stable
+      integration-test-juju-channel: 3.1/stable

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # This file defines charm config options, and populates the Configure tab on Charmhub.
 # If your charm does not require configuration options, delete this file entirely.
 #

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100px"
+   height="100px"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="icon.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>eclispe-che</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1206"
+     inkscape:window-height="736"
+     id="namedview20"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.72"
+     inkscape:cx="45.338983"
+     inkscape:cy="57.521186"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <!-- Generator: Sketch 45.2 (43514) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title2">eclispe-che</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <defs
+     id="defs7">
+    <path
+       d="M50.0004412,4.04252804e-14 C22.3871247,4.04252804e-14 0,22.3848726 0,49.9995588 C0,77.6133626 22.3871247,100 50.0004412,100 C77.6137577,100 100,77.6133626 100,49.9995588 C100,22.3848726 77.6128753,3.55271368e-14 50.0004412,4.04252804e-14 Z"
+       id="path-1" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <rect
+         style="opacity:0.5;fill:#000000;stroke-width:10.613"
+         id="rect416"
+         width="521.27826"
+         height="440.85867"
+         x="674.51324"
+         y="368.65756" />
+    </clipPath>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="BACKGROUND">
+    <g
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="Page-1">
+      <g
+         id="eclispe-che"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+        <g
+           id="path3023-path"
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+          <use
+             xlink:href="#path-1"
+             id="use9"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-opacity:1"
+             x="0"
+             y="0"
+             width="100%"
+             height="100%" />
+          <path
+             d="M 50.000441,0.5 C 22.662621,0.5 0.5,22.661661 0.5,49.999559 0.5,77.337051 22.663098,99.5 50.000441,99.5 77.337613,99.5 99.5,77.337222 99.5,49.999559 99.5,22.661796 77.337514,0.5 50.000441,0.5 Z"
+             id="path11"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g228"
+       transform="matrix(0.21943857,0,0,0.21943857,-153.8929,-79.487101)"
+       clip-path="url(#clipPath414)">
+      <g
+         id="g224">
+        <polygon
+           class="st0"
+           points="466.6,913.6 524.4,913.6 524.4,895.8 389.9,895.8 389.9,913.6 447.5,913.6 447.5,1064.2 466.6,1064.2 "
+           id="polygon208"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 791.7,942.6 c -17.7,0 -30.6,7.2 -38.6,21.3 -6.2,-14.2 -17.9,-21.3 -34.7,-21.3 -13.6,0 -24.4,4.8 -31.5,14.1 v -12.1 h -18 l 0.2,119.7 h 18.5 v -57.6 c 0,-31.9 9.3,-47.5 28.4,-47.5 16.9,0 25.5,12.1 25.5,36 v 69.1 H 760 v -57.6 c 0,-31.9 9.6,-47.5 29.3,-47.5 24.8,0 24.8,24.6 24.8,35.1 v 70 h 18.5 v -74.5 c 0,-30.9 -14.1,-47.2 -40.9,-47.2 z"
+           id="path210"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 578.6,942.6 c -36.8,0 -53.3,31.3 -53.3,62.4 0,37.2 21.7,61.2 55.2,61.2 19.3,0 32.7,-5.8 46.3,-20.1 l 0.7,-0.8 -13,-11.3 -0.7,0.7 c -9.7,10.3 -19.3,14.5 -33.2,14.5 -22.4,0 -36.1,-14.7 -36.9,-39.3 h 86 l 0.1,-0.8 c 0.4,-2.7 0.7,-6.7 0.7,-10.4 0,-14.7 -4.3,-28.2 -12.2,-38.1 -9.1,-11.8 -22.9,-18 -39.7,-18 z m 0,15.8 c 19.8,0 32.8,12.5 34.1,32.7 0,1.2 0.1,2.2 0.1,2.8 h -69 c 1.9,-21.2 15.8,-35.5 34.8,-35.5 z"
+           id="path212"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1425,1047.9 v -152 h -17.4 v 153.4 c 0,8.7 7.2,15.7 16,15.7 h 27.6 v -17 H 1425 Z"
+           id="path214"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1314,942.6 c -20.4,0 -35.9,7.8 -48.8,24.5 l -0.6,0.8 13.5,11.3 0.6,-0.9 c 9.5,-13.1 20.6,-19.2 35,-19.2 19.3,0 29.6,10.6 29.6,30.8 v 4.5 h -23.1 c -22.9,0 -36,2.1 -45.2,7.3 -9.2,5.7 -14.1,15.2 -14.1,27.4 0,23.2 15.6,37.1 41.6,37.1 17.9,0 31.8,-6.1 41.4,-18.3 l 0.9,16.3 h 17 v -74.3 c 0,-14.7 -4.3,-26.7 -12.6,-34.9 -8.2,-8.1 -20.4,-12.4 -35.2,-12.4 z m 29.3,67.2 v 0.7 c 0,24.7 -13.8,40.1 -36,40.1 -17.2,0 -27.9,-7.9 -27.9,-20.5 0,-6.5 2,-11.4 6.1,-14.5 5.4,-4.3 14.6,-5.8 36.2,-5.8 z"
+           id="path216"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 934.5,942.4 c -15.7,0 -28.8,5.6 -37.9,16.1 v -14 H 878.1 V 1113 h 18.5 v -62.7 c 9.2,10.4 22.2,15.9 37.9,15.9 32.9,0 53.3,-23.7 53.3,-61.9 0,-18.4 -4.9,-34 -14.1,-44.9 -9.4,-11.1 -22.9,-17 -39.2,-17 z m 34.9,61.9 c 0,13.3 -3.3,24.6 -9.5,32.6 -6.5,8.3 -16.1,12.7 -27.7,12.7 -22.8,0 -37,-17.4 -37,-45.3 0,-27.9 14.2,-45.3 37,-45.3 22.9,-0.1 37.2,17.3 37.2,45.3 z"
+           id="path218"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1074.5,942.6 c -16.4,0 -31.2,6.2 -41.5,17.6 -10.2,11.2 -15.8,26.8 -15.8,44.1 0,17.3 5.6,33 15.8,44.2 10.4,11.4 25.1,17.7 41.5,17.7 33.4,0 57.6,-26 57.6,-61.9 0,-17.2 -5.7,-32.9 -16,-44.1 -10.5,-11.4 -25.3,-17.6 -41.6,-17.6 z m 39.1,61.7 c 0,12.8 -3.7,24.3 -10.3,32.4 -7,8.5 -17,13 -28.8,13 -23.6,0 -38.9,-17.8 -38.9,-45.3 0,-27.4 15.3,-45.1 38.9,-45.1 23.7,-0.1 39.1,17.6 39.1,45 z"
+           id="path220"
+           style="fill:#141414" />
+        <path
+           class="st0"
+           d="m 1223,942.6 c -10.5,0 -24.6,3 -33.9,17 v -15.1 h -18.5 v 119.7 h 18.5 v -66.7 c 0,-23.5 11.7,-38.2 30.5,-38.2 4.8,0 9.6,1.1 15.1,3.5 l 0.8,0.3 9.1,-15 -0.9,-0.5 c -6.1,-3.3 -12.9,-5 -20.7,-5 z"
+           id="path222"
+           style="fill:#141414" />
+      </g>
+      <path
+         class="st0"
+         d="m 999.1,518.2 c -9.2,-68.8 -32.4,-126.3 -68.2,-126.3 -35.7,0 -59,57.5 -68.2,126.3 -68.8,9.2 -126.3,32.4 -126.3,68.2 0,35.7 57.5,59 126.3,68.2 9.2,68.8 32.4,126.3 68.2,126.3 35.7,0 59,-57.5 68.2,-126.3 68.8,-9.2 126.3,-32.4 126.3,-68.2 0,-35.8 -57.5,-59.1 -126.3,-68.2 z M 860.5,634.4 c -65.9,-9.5 -104.4,-31.3 -104.4,-48.1 0,-16.8 38.4,-38.6 104.4,-48.1 -1.5,15.9 -2.2,32.1 -2.2,48.1 0,16 0.7,32.3 2.2,48.1 z m 70.4,-222.9 c 16.8,0 38.6,38.4 48.1,104.4 -15.9,-1.5 -32.1,-2.2 -48.1,-2.2 -16,0 -32.2,0.8 -48.1,2.2 9.5,-65.9 31.3,-104.4 48.1,-104.4 z m 70.4,222.9 c -3.2,0.5 -16.6,2 -19.9,2.4 -0.3,3.4 -1.9,16.7 -2.4,19.9 -9.5,65.9 -31.3,104.4 -48.1,104.4 -16.8,0 -38.6,-38.4 -48.1,-104.4 -0.5,-3.2 -2,-16.6 -2.4,-19.9 -1.5,-15.6 -2.5,-32.4 -2.5,-50.5 0,-18.1 0.9,-34.8 2.5,-50.5 15.6,-1.5 32.4,-2.5 50.5,-2.5 18.1,0 34.8,0.9 50.5,2.5 3.4,0.3 16.7,1.9 19.9,2.4 65.9,9.5 104.4,31.3 104.4,48.1 0,16.8 -38.5,38.6 -104.4,48.1 z"
+         id="path226"
+         style="fill:#141414" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="PLACE LOGO HERE" />
+</svg>

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,6 +16,7 @@ description: |
 maintainers: 
   - Commercial Systems <jaas-crew@lists.canonical.com>
 source: https://github.com/canonical/temporal-worker-k8s-operator
+docs: https://github.com/canonical/temporal-worker-k8s-operator
 tags:
   - temporal
   - workflow

--- a/resource_sample/pyproject.toml
+++ b/resource_sample/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 [tool.poetry]
 name = "python-samples"
 version = "1.1.0"

--- a/resource_sample/resource_sample/activities/activity1.py
+++ b/resource_sample/resource_sample/activities/activity1.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 from temporalio import activity
 from dataclasses import dataclass
 from resource_sample.common.messages import ComposeGreetingInput

--- a/resource_sample/resource_sample/activities/activity2.py
+++ b/resource_sample/resource_sample/activities/activity2.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 from temporalio import activity
 from dataclasses import dataclass
 from resource_sample.common.messages import ComposeGreetingInput

--- a/resource_sample/resource_sample/common/messages.py
+++ b/resource_sample/resource_sample/common/messages.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 from dataclasses import dataclass
 
 @dataclass

--- a/resource_sample/resource_sample/workflows/workflow1.py
+++ b/resource_sample/resource_sample/workflows/workflow1.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 from datetime import timedelta
 
 from temporalio import workflow

--- a/resource_sample/resource_sample/workflows/workflow2.py
+++ b/resource_sample/resource_sample/workflows/workflow2.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 from datetime import timedelta
 
 from temporalio import workflow

--- a/src/charm.py
+++ b/src/charm.py
@@ -243,7 +243,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             return
 
         # ensure the container is set up
-        self._setup_container(container)
+        _setup_container(container)
 
         logger.info("Configuring Temporal worker")
 
@@ -270,22 +270,22 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
 
         self.unit.status = ActiveStatus()
 
-    def _setup_container(self, container: Container):
-        """Copy worker file to the container and install dependencies.
+def _setup_container(self, container: Container):
+    """Copy worker file to the container and install dependencies.
 
-        Args:
-            container: Container unit on which to perform action.
-        """
-        resources_path = Path(__file__).parent / "resources"
-        _push_container_file(container, resources_path, "/worker.py", resources_path / "worker.py")
-        _push_container_file(
-            container, resources_path, "/worker-dependencies.txt", resources_path / "worker-dependencies.txt"
-        )
+    Args:
+        container: Container unit on which to perform action.
+    """
+    resources_path = Path(__file__).parent / "resources"
+    _push_container_file(container, resources_path, "/worker.py", resources_path / "worker.py")
+    _push_container_file(
+        container, resources_path, "/worker-dependencies.txt", resources_path / "worker-dependencies.txt"
+    )
 
-        # Install worker dependencies
-        worker_dependencies_path = "/worker-dependencies.txt"
-        logger.info("installing worker dependencies...")
-        container.exec(["pip", "install", "-r", str(worker_dependencies_path)]).wait_output()
+    # Install worker dependencies
+    worker_dependencies_path = "/worker-dependencies.txt"
+    logger.info("installing worker dependencies...")
+    container.exec(["pip", "install", "-r", str(worker_dependencies_path)]).wait_output()
 
 def _validate_wheel_name(filename):
     """Validate wheel file name.

--- a/src/charm.py
+++ b/src/charm.py
@@ -243,7 +243,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             return
 
         # ensure the container is set up
-        _setup_container(container)
+        self._setup_container(container)
 
         logger.info("Configuring Temporal worker")
 
@@ -270,6 +270,22 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
 
         self.unit.status = ActiveStatus()
 
+    def _setup_container(self, container: Container):
+        """Copy worker file to the container and install dependencies.
+
+        Args:
+            container: Container unit on which to perform action.
+        """
+        resources_path = Path(__file__).parent / "resources"
+        _push_container_file(container, resources_path, "/worker.py", resources_path / "worker.py")
+        _push_container_file(
+            container, resources_path, "/worker-dependencies.txt", resources_path / "worker-dependencies.txt"
+        )
+
+        # Install worker dependencies
+        worker_dependencies_path = "/worker-dependencies.txt"
+        logger.info("installing worker dependencies...")
+        container.exec(["pip", "install", "-r", str(worker_dependencies_path)]).wait_output()
 
 def _validate_wheel_name(filename):
     """Validate wheel file name.
@@ -280,28 +296,9 @@ def _validate_wheel_name(filename):
     Returns:
         True if the file name is valid, False otherwise.
     """
-    # Define a whitelist of allowed characters and patterns
+    # Define an allowed list of allowed characters and patterns
     allowed_pattern = r"^[a-zA-Z0-9-._]+-[a-zA-Z0-9_.]+-([a-zA-Z0-9_.]+|any|py2.py3)-(none|linux|macosx|win)-(any|any|intel|amd64)\.whl$"
-    return bool(re.search(allowed_pattern, filename))
-
-
-def _setup_container(container: Container):
-    """Copy worker file to the container and install dependencies.
-
-    Args:
-        container: Container unit on which to perform action.
-    """
-    resources_path = Path(__file__).parent / "resources"
-    _push_container_file(container, resources_path, "/worker.py", resources_path / "worker.py")
-    _push_container_file(
-        container, resources_path, "/worker-dependencies.txt", resources_path / "worker-dependencies.txt"
-    )
-
-    # Install worker dependencies
-    worker_dependencies_path = "/worker-dependencies.txt"
-    logger.info("installing worker dependencies...")
-    container.exec(["pip", "install", "-r", str(worker_dependencies_path)]).wait_output()
-
+    return bool(re.match(allowed_pattern, filename))
 
 def _push_container_file(container: Container, src_path, dest_path, resource):
     """Copy worker file to the container and install dependencies.

--- a/src/charm.py
+++ b/src/charm.py
@@ -270,7 +270,8 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
 
         self.unit.status = ActiveStatus()
 
-def _setup_container(self, container: Container):
+
+def _setup_container(container: Container):
     """Copy worker file to the container and install dependencies.
 
     Args:
@@ -287,6 +288,7 @@ def _setup_container(self, container: Container):
     logger.info("installing worker dependencies...")
     container.exec(["pip", "install", "-r", str(worker_dependencies_path)]).wait_output()
 
+
 def _validate_wheel_name(filename):
     """Validate wheel file name.
 
@@ -299,6 +301,7 @@ def _validate_wheel_name(filename):
     # Define an allowed list of allowed characters and patterns
     allowed_pattern = r"^[a-zA-Z0-9-._]+-[a-zA-Z0-9_.]+-([a-zA-Z0-9_.]+|any|py2.py3)-(none|linux|macosx|win)-(any|any|intel|amd64)\.whl$"
     return bool(re.match(allowed_pattern, filename))
+
 
 def _push_container_file(container: Container, src_path, dest_path, resource):
     """Copy worker file to the container and install dependencies.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal worker charm integration test config."""
+
+import logging
+
+import pytest
+import pytest_asyncio
+from helpers import (
+    APP_NAME,
+    APP_NAME_ADMIN,
+    APP_NAME_SERVER,
+    APP_NAME_UI,
+    METADATA,
+    WORKER_CONFIG,
+    create_default_namespace,
+    get_application_url,
+    perform_temporal_integrations,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy", scope="module")
+async def deploy(ops_test: OpsTest):
+    """Verify the app is up and running."""
+    charm = await ops_test.build_charm(".")
+    resources = {"temporal-worker-image": METADATA["containers"]["temporal-worker"]["upstream-source"]}
+
+    # Deploy temporal server, temporal admin and postgresql charms.
+    await ops_test.model.deploy(charm, resources=resources, config=WORKER_CONFIG, application_name=APP_NAME)
+    await ops_test.model.deploy(APP_NAME_SERVER, channel="edge")
+    await ops_test.model.deploy(APP_NAME_ADMIN, channel="edge")
+    await ops_test.model.deploy(APP_NAME_UI, channel="edge")
+    await ops_test.model.deploy("postgresql-k8s", channel="14", trust=True)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, APP_NAME_SERVER, APP_NAME_ADMIN, APP_NAME_UI],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
+        )
+
+        await perform_temporal_integrations(ops_test)
+
+        await create_default_namespace(ops_test)
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME_SERVER], status="active", raise_on_blocked=False, timeout=300)
+        assert ops_test.model.applications[APP_NAME_SERVER].units[0].workload_status == "active"
+        assert ops_test.model.applications[APP_NAME_UI].units[0].workload_status == "active"
+
+        url = await get_application_url(ops_test, application=APP_NAME_SERVER, port=7233)
+
+        await ops_test.model.applications[APP_NAME].set_config({"host": url})
+
+        rsc_name = "workflows-file"
+        # TODO(kelkawi-a): build wheel file here and refer to it
+        rsc_path = "./resource_sample/dist/python_samples-1.1.0-py3-none-any.whl"
+        logger.info(f"Attaching resource: attach-resource {APP_NAME} {rsc_name}={rsc_path}")
+        await ops_test.juju("attach-resource", APP_NAME, f"{rsc_name}={rsc_path}")
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=120)
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal charm integration test helpers."""
+
+import logging
+from pathlib import Path
+
+import yaml
+from pytest_operator.plugin import OpsTest
+from temporal_client.activities import ComposeGreetingInput
+from temporal_client.workflows import GreetingWorkflow
+from temporalio.client import Client
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+APP_NAME_SERVER = "temporal-k8s"
+APP_NAME_ADMIN = "temporal-admin-k8s"
+APP_NAME_UI = "temporal-ui-k8s"
+
+WORKER_CONFIG = {
+    "log-level": "debug",
+    "namespace": "default",
+    "queue": "my-task-queue",
+    "auth-enabled": False,
+    "auth-provider": "candid",
+    "candid-url": "test-url",
+    "candid-username": "test-username",
+    "candid-private-key": "test-private-key",
+    "candid-public-key": "test-public-key",
+}
+
+
+async def run_sample_workflow(ops_test: OpsTest):
+    """Connect to a client and runs a basic Temporal workflow.
+
+    Args:
+        ops_test: PyTest object.
+    """
+    url = await get_application_url(ops_test, application=APP_NAME, port=7233)
+    logger.info("running workflow on app address: %s", url)
+
+    client = await Client.connect(url)
+
+    # Execute workflow
+    name = "Jean-luc"
+    result = await client.execute_workflow(
+        GreetingWorkflow.run, ComposeGreetingInput("Hello", name), id="my-workflow-id", task_queue="my-task-queue"
+    )
+    logger.info(f"result: {result}")
+    assert result == f"Hello, {name}!"
+
+
+async def create_default_namespace(ops_test: OpsTest):
+    """Create default namespace on Temporal server using tctl.
+
+    Args:
+        ops_test: PyTest object.
+    """
+    # Register default namespace from admin charm.
+    action = (
+        await ops_test.model.applications[APP_NAME_ADMIN]
+        .units[0]
+        .run_action("tctl", args="--ns default namespace register -rd 3")
+    )
+    result = (await action.wait()).results
+    logger.info(f"tctl result: {result}")
+    assert "result" in result and result["result"] == "command succeeded"
+
+
+async def get_application_url(ops_test: OpsTest, application, port):
+    """Return application URL from the model.
+
+    Args:
+        ops_test: PyTest object.
+        application: Name of the application.
+        port: Port number of the URL.
+
+    Returns:
+        Application URL of the form {address}:{port}
+    """
+    status = await ops_test.model.get_status()  # noqa: F821
+    address = status["applications"][application].public_address
+    return f"{address}:{port}"
+
+
+async def get_unit_url(ops_test: OpsTest, application, unit, port, protocol="http"):
+    """Return unit URL from the model.
+
+    Args:
+        ops_test: PyTest object.
+        application: Name of the application.
+        unit: Number of the unit.
+        port: Port number of the URL.
+        protocol: Transfer protocol (default: http).
+
+    Returns:
+        Unit URL of the form {protocol}://{address}:{port}
+    """
+    status = await ops_test.model.get_status()  # noqa: F821
+    address = status["applications"][application]["units"][f"{application}/{unit}"]["address"]
+    return f"{protocol}://{address}:{port}"
+
+
+async def perform_temporal_integrations(ops_test: OpsTest):
+    """Integrate Temporal charm with postgresql, admin and ui charms.
+
+    Args:
+        ops_test: PyTest object.
+    """
+    await ops_test.model.integrate(f"{APP_NAME_SERVER}:db", "postgresql-k8s:database")
+    await ops_test.model.integrate(f"{APP_NAME_SERVER}:visibility", "postgresql-k8s:database")
+    await ops_test.model.integrate(f"{APP_NAME_SERVER}:admin", f"{APP_NAME_ADMIN}:admin")
+    await ops_test.model.wait_for_idle(apps=[APP_NAME_SERVER], status="active", raise_on_blocked=False, timeout=180)
+    await ops_test.model.integrate(f"{APP_NAME_SERVER}:ui", f"{APP_NAME_UI}:ui")
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME_SERVER, APP_NAME_UI], status="active", raise_on_blocked=False, timeout=180
+    )
+
+    assert ops_test.model.applications[APP_NAME_SERVER].units[0].workload_status == "active"

--- a/tests/integration/temporal_client/activities.py
+++ b/tests/integration/temporal_client/activities.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Temporal client activity."""
+
+# pylint: disable=R0801
+
+from dataclasses import dataclass
+
+from temporalio import activity
+
+
+@dataclass
+class ComposeGreetingInput:
+    """GreetingInput class.
+
+    Attrs:
+        greeting: blah.
+        name: blah.
+    """
+
+    greeting: str
+    name: str
+
+
+# Basic activity that logs and does string concatenation
+@activity.defn(name="compose_greeting")
+async def compose_greeting(arg: ComposeGreetingInput) -> str:
+    """Temporal activity.
+
+    Args:
+        arg: ComposeGreetingInput used to run the dynamic activity.
+
+    Returns:
+        String in the form "Hello, {name}!
+    """
+    activity.logger.info(f"Running activity with parameter {arg}")
+    return f"{arg.greeting}, {arg.name}!"

--- a/tests/integration/temporal_client/workflows.py
+++ b/tests/integration/temporal_client/workflows.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Temporal client sample workflow."""
+
+# pylint: disable=R0801
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+# Import our activity, passing it through the sandbox
+with workflow.unsafe.imports_passed_through():
+    from .activities import ComposeGreetingInput, compose_greeting
+
+
+# Basic workflow that logs and invokes an activity
+@workflow.defn(name="GreetingWorkflow")
+class GreetingWorkflow:
+    """Temporal workflow class."""
+
+    @workflow.run
+    async def run(self, name: str) -> str:
+        """Workflow execution method.
+
+        Args:
+            name: input for workflow execution.
+
+        Returns:
+            Workflow execution result.
+        """
+        workflow.logger.info(f"Running workflow with parameter {name}")
+        return await workflow.execute_activity(
+            compose_greeting,
+            ComposeGreetingInput("Hello", name),
+            start_to_close_timeout=timedelta(seconds=10),
+        )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,32 +4,24 @@
 
 """Temporal worker charm integration tests."""
 
-import asyncio
 import logging
-from pathlib import Path
 
 import pytest
-import yaml
+from conftest import deploy  # noqa: F401, pylint: disable=W0611
+from helpers import run_sample_workflow
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
-
+# Skipped until local resources are supported:
+# https://pythonlibjuju.readthedocs.io/en/latest/api/juju.model.html?highlight=deploy#juju.model.Model.deploy
+@pytest.mark.skip
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm-under-test and deploy it together with related charms.
+@pytest.mark.usefixtures("deploy")
+class TestDeployment:
+    """Integration tests for Temporal charm."""
 
-    Assert on the unit status before any relations/configurations take place.
-    """
-    # Build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
-    resources = {"httpbin-image": METADATA["resources"]["httpbin-image"]["upstream-source"]}
-
-    # Deploy the charm and wait for active/idle status
-    await asyncio.gather(
-        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
-        ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000),
-    )
+    async def test_basic_client(self, ops_test: OpsTest):
+        """Connects a client and runs a basic Temporal workflow."""
+        await run_sample_workflow(ops_test)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -55,7 +55,7 @@ class TestCharm(TestCase):
         self.assertEqual(harness.model.unit.status, BlockedStatus("Invalid config: host value missing"))
 
     @mock.patch("charm.TemporalWorkerK8SOperatorCharm._process_wheel_file")
-    @mock.patch("charm.TemporalWorkerK8SOperatorCharm._setup_container")
+    @mock.patch("charm._setup_container")
     def test_ready(self, _process_wheel_file, _setup_container):
         """The charm is blocked without a admin:temporal relation with a ready schema."""
         harness = self.harness

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,72 +3,207 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-"""Temporal charm integration tests."""
+"""Temporal worker charm unit tests."""
 
-import unittest
+import json
+from unittest import TestCase, mock
 
-import ops
-import ops.testing
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
 
 from charm import TemporalWorkerK8SOperatorCharm
+from state import State
+
+CONTAINER_NAME = "temporal-worker"
 
 
-class TestCharm(unittest.TestCase):
-    """Unit tests."""
+class TestCharm(TestCase):
+    """Unit tests.
+
+    Attrs:
+        maxDiff: Specifies max difference shown by failed tests.
+    """
+
+    maxDiff = None
 
     def setUp(self):
         """Set up for the unit tests."""
-        self.harness = ops.testing.Harness(TemporalWorkerK8SOperatorCharm)
+        self.harness = Harness(TemporalWorkerK8SOperatorCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_can_connect(CONTAINER_NAME, True)
+        self.harness.set_leader(True)
         self.harness.begin()
 
-    def test_httpbin_pebble_ready(self):
-        """Expected plan after Pebble ready with default config."""
-        expected_plan = {
+    def test_initial_plan(self):
+        """The initial pebble plan is empty."""
+        harness = self.harness
+        initial_plan = harness.get_container_pebble_plan(CONTAINER_NAME).to_dict()
+        self.assertEqual(initial_plan, {})
+
+    @mock.patch("charm.TemporalWorkerK8SOperatorCharm._process_wheel_file")
+    def test_attach_resource(self, _process_wheel_file):
+        """The workflows file resource can be attached."""
+        harness = self.harness
+
+        # Simulate peer relation readiness.
+        harness.add_relation("peer", "temporal")
+        harness.add_resource("workflows-file", "")
+
+        harness.charm.on.config_changed.emit()
+        _process_wheel_file.assert_called()
+
+        self.assertEqual(harness.model.unit.status, BlockedStatus("Invalid config: host value missing"))
+
+    @mock.patch("charm.TemporalWorkerK8SOperatorCharm._process_wheel_file")
+    @mock.patch("charm.TemporalWorkerK8SOperatorCharm._setup_container")
+    def test_ready(self, _process_wheel_file, _setup_container):
+        """The charm is blocked without a admin:temporal relation with a ready schema."""
+        harness = self.harness
+
+        config = {
+            "log-level": "debug",
+            "host": "test-host",
+            "namespace": "test-namespace",
+            "queue": "test-queue",
+            "workflows-file-name": "python_samples-1.1.0-py3-none-any.whl",
+            "encryption-key": "",
+            "auth-enabled": True,
+            "auth-provider": "candid",
+            "tls-root-cas": "",
+            "candid-url": "test-url",
+            "candid-username": "test-username",
+            "candid-public-key": "test-public-key",
+            "candid-private-key": "test-private-key",
+            "oidc-auth-type": "",
+            "oidc-project-id": "",
+            "oidc-private-key-id": "",
+            "oidc-private-key": "",
+            "oidc-client-email": "",
+            "oidc-client-id": "",
+            "oidc-auth-uri": "",
+            "oidc-token-uri": "",
+            "oidc-auth-cert-url": "",
+            "oidc-client-cert-url": "",
+        }
+        state = simulate_lifecycle(harness, config)
+        harness.charm.on.config_changed.emit()
+
+        sw = json.loads(state["supported_workflows"])
+        sa = json.loads(state["supported_activities"])
+        module_name = json.loads(state["module_name"])
+
+        self.assertEqual(harness.model.unit.status, ActiveStatus())
+
+        command = f"python worker.py '{json.dumps(dict(config))}' '{','.join(sw)}' '{','.join(sa)}' {module_name}"
+
+        # The plan is generated after pebble is ready.
+        want_plan = {
             "services": {
-                "httpbin": {
-                    "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
+                "temporal-worker": {
+                    "summary": "temporal worker",
+                    "command": command,
                     "startup": "enabled",
-                    "environment": {"GUNICORN_CMD_ARGS": "--log-level info"},
+                    "override": "replace",
                 }
             },
         }
-        # Simulate the container coming up and emission of pebble-ready event
-        self.harness.container_pebble_ready("httpbin")
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        # Check we've got the plan we expected
-        self.assertEqual(expected_plan, updated_plan)
-        # Check the service was started
-        service = self.harness.model.unit.get_container("httpbin").get_service("httpbin")
+        got_plan = harness.get_container_pebble_plan("temporal-worker").to_dict()
+        self.assertEqual(got_plan, want_plan)
+
+        # The service was started.
+        service = harness.model.unit.get_container(CONTAINER_NAME).get_service("temporal-worker")
         self.assertTrue(service.is_running())
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
-    def test_config_changed_valid_can_connect(self):
-        """Ensure the simulated Pebble API is reachable."""
-        self.harness.set_can_connect("httpbin", True)
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "debug"})
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        updated_env = updated_plan["services"]["httpbin"]["environment"]
-        # Check the config change was effective
-        self.assertEqual(updated_env, {"GUNICORN_CMD_ARGS": "--log-level debug"})
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+        # The ActiveStatus is set with no message.
+        self.assertEqual(harness.model.unit.status, ActiveStatus())
 
-    def test_config_changed_valid_cannot_connect(self):
-        """Trigger a config-changed event with an updated value."""
-        self.harness.update_config({"log-level": "debug"})
-        # Check the charm is in WaitingStatus
-        self.assertIsInstance(self.harness.model.unit.status, ops.WaitingStatus)
 
-    def test_config_changed_invalid(self):
-        """Ensure the simulated Pebble API is reachable."""
-        self.harness.set_can_connect("httpbin", True)
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "foobar"})
-        # Check the charm is in BlockedStatus
-        self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+def simulate_lifecycle(harness, config):
+    """Simulate a healthy charm life-cycle.
+
+    Args:
+        harness: ops.testing.Harness object used to simulate charm lifecycle.
+        config: object to update the charm's config.
+
+    Returns:
+        Peer relation data.
+    """
+    # Simulate peer relation readiness.
+    rel = harness.add_relation("peer", "temporal")
+
+    # Simulate pebble readiness.
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.temporal_worker_pebble_ready.emit(container)
+
+    harness.update_config(config)
+    harness.add_resource("workflows-file", "bytes_content")
+
+    harness.update_relation_data(
+        rel,
+        app_or_unit="temporal-worker-k8s",
+        key_values={
+            "supported_workflows": json.dumps(["TestWorkflow"]),
+            "supported_activities": json.dumps(["test_activity"]),
+            "module_name": json.dumps("python_samples"),
+        },
+    )
+
+    return harness.get_relation_data(rel, "temporal-worker-k8s")
+
+
+class TestState(TestCase):
+    """Unit tests for state.
+
+    Attrs:
+        maxDiff: Specifies max difference shown by failed tests.
+    """
+
+    maxDiff = None
+
+    def test_get(self):
+        """It is possible to retrieve attributes from the state."""
+        state = make_state({"foo": json.dumps("bar")})
+        self.assertEqual(state.foo, "bar")
+        self.assertIsNone(state.bad)
+
+    def test_set(self):
+        """It is possible to set attributes in the state."""
+        data = {"foo": json.dumps("bar")}
+        state = make_state(data)
+        state.foo = 42
+        state.list = [1, 2, 3]
+        self.assertEqual(state.foo, 42)
+        self.assertEqual(state.list, [1, 2, 3])
+        self.assertEqual(data, {"foo": "42", "list": "[1, 2, 3]"})
+
+    def test_del(self):
+        """It is possible to unset attributes in the state."""
+        data = {"foo": json.dumps("bar"), "answer": json.dumps(42)}
+        state = make_state(data)
+        del state.foo
+        self.assertIsNone(state.foo)
+        self.assertEqual(data, {"answer": "42"})
+        # Deleting a name that is not set does not error.
+        del state.foo
+
+    def test_is_ready(self):
+        """The state is not ready when it is not possible to get relations."""
+        state = make_state({})
+        self.assertTrue(state.is_ready())
+
+        state = State("myapp", lambda: None)
+        self.assertFalse(state.is_ready())
+
+
+def make_state(data):
+    """Create state object.
+
+    Args:
+        data: Data to be included in state.
+
+    Returns:
+        State object with data.
+    """
+    app = "myapp"
+    rel = type("Rel", (), {"data": {app: data}})()
+    return State(app, lambda: rel)


### PR DESCRIPTION
This PR addresses the following:
- Adds the CI/CD [operator workflows](https://github.com/canonical/operator-workflows) github actions for unit, linting and integration tests on PRs. 
- Adds unit tests
- Adds an integration test which is skipped for now until juju provides the ability to attach local resources.
- Some general code refactoring

Recently, the IS Devops team has made changes to the operator workflows which require further branch protection rules before the checks can be applied. The branch protection rules for this repo have been updated as follows:
- ```main``` branch:
   - Require review from code owners.
   - Require signed commits.
   - Dismiss stale pull request approvals when new commits are pushed.
   - Allow specified actors to bypass required pull requests _unchecked_.

- ```*``` branch pattern: Require signed commits.