### PR TITLE
Use wheel unpack instead of unzip

### DIFF
--- a/src/resources/worker-dependencies.txt
+++ b/src/resources/worker-dependencies.txt
@@ -1,2 +1,3 @@
-temporal-lib-py==1.1.1
+temporal-lib-py==1.1.2
 protobuf==3.20.0
+wheel==0.41.2

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -94,8 +94,9 @@ class TestCharm(TestCase):
         harness.charm.on.config_changed.emit()
 
         module_name = json.loads(state["module_name"])
+        unpacked_file_name = json.loads(state["unpacked_file_name"])
 
-        command = f"python worker.py '{json.dumps(dict(config))}' {module_name}"
+        command = f"python worker.py '{json.dumps(dict(config))}' {unpacked_file_name} {module_name}"
 
         # The plan is generated after pebble is ready.
         want_plan = {
@@ -149,6 +150,7 @@ def simulate_lifecycle(harness, config):
             "supported_workflows": json.dumps(["TestWorkflow"]),
             "supported_activities": json.dumps(["test_activity"]),
             "module_name": json.dumps("python_samples"),
+            "unpacked_file_name": json.dumps("python_sample-0.1.0"),
         },
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
     isort --check-only --diff {[vars]all_path} 
     black --check --diff {[vars]all_path} 
     mypy {[vars]all_path} --ignore-missing-imports --install-types --non-interactive --explicit-package-bases
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0301,C0103,C0104,R0914
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0301,C0103,C0104,R0914,R0915
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
Usage of ```unzip``` requires it to be installed using ```apt-get``` which sometimes faces proxy issues. This change opts for the use of ```wheel unpack``` with some slight modifications to execute the same logic.