### PR TITLE
CSS-6912: Add workload container health check

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,6 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Canonical Ltd.
+    copyright-year: 2023
     content: |
       Copyright [year] [owner]
       See LICENSE file for licensing details.

--- a/src/resources/check_status.py
+++ b/src/resources/check_status.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal worker status checker."""
+
+
+import sys
+
+
+def check_worker_status():
+    """Check Temporal worker status by reading status file."""
+    try:
+        with open("worker_status.txt", "r") as status_file:
+            status = status_file.read().strip()
+            print(f"Async status: {status}")
+
+        if "Error" in status:
+            exit_code = 1
+        else:
+            exit_code = 0
+    except FileNotFoundError:
+        print("Status file not found. Worker is not running.")
+        exit_code = 1
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    check_worker_status()

--- a/src/resources/check_status.py
+++ b/src/resources/check_status.py
@@ -5,7 +5,10 @@
 """Temporal worker status checker."""
 
 
+import logging
 import sys
+
+logger = logging.getLogger(__name__)
 
 
 def check_worker_status():
@@ -13,14 +16,14 @@ def check_worker_status():
     try:
         with open("worker_status.txt", "r") as status_file:
             status = status_file.read().strip()
-            print(f"Async status: {status}")
+            logger.info(f"Async status: {status}")
 
         if "Error" in status:
             exit_code = 1
         else:
             exit_code = 0
     except FileNotFoundError:
-        print("Status file not found. Worker is not running.")
+        logger.error("Status file not found. Worker is not running.")
         exit_code = 1
 
     sys.exit(exit_code)

--- a/src/resources/worker.py
+++ b/src/resources/worker.py
@@ -147,7 +147,15 @@ async def run_worker(unpacked_file_name, module_name):
         activities=activities,
         worker_opt=worker_opt,
     )
-    await worker.run()
+
+    try:
+        with open("worker_status.txt", "w") as status_file:
+            status_file.write("Success")
+        await worker.run()
+    except Exception as e:
+        # If an error occurs, write the error message to the status file
+        with open("worker_status.txt", "w") as status_file:
+            status_file.write(f"Error: {e}")
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/resources/worker.py
+++ b/src/resources/worker.py
@@ -104,51 +104,51 @@ async def run_worker(unpacked_file_name, module_name):
         queue=os.getenv("TWC_QUEUE"),
     )
 
-    workflows = _import_modules(
-        "workflows",
-        unpacked_file_name=unpacked_file_name,
-        module_name=module_name,
-        supported_modules=os.getenv("TWC_SUPPORTED_WORKFLOWS").split(","),
-    )
-    activities = _import_modules(
-        "activities",
-        unpacked_file_name=unpacked_file_name,
-        module_name=module_name,
-        supported_modules=os.getenv("TWC_SUPPORTED_ACTIVITIES").split(","),
-    )
-
-    if os.getenv("TWC_TLS_ROOT_CAS").strip() != "":
-        client_config.tls_root_cas = os.getenv("TWC_TLS_ROOT_CAS")
-
-    if os.getenv("TWC_AUTH_PROVIDER").strip() != "":
-        client_config.auth = AuthOptions(provider=os.getenv("TWC_AUTH_PROVIDER"), config=_get_auth_header())
-
-    if os.getenv("TWC_ENCRYPTION_KEY").strip() != "":
-        client_config.encryption = EncryptionOptions(key=os.getenv("TWC_ENCRYPTION_KEY"), compress=True)
-
-    worker_opt = None
-    dsn = os.getenv("TWC_SENTRY_DSN").strip()
-    if dsn != "":
-        sentry = SentryOptions(
-            dsn=dsn,
-            release=os.getenv("TWC_SENTRY_RELEASE").strip() or None,
-            environment=os.getenv("TWC_SENTRY_ENVIRONMENT").strip() or None,
-            redact_params=os.getenv("TWC_SENTRY_REDACT_PARAMS"),
+    try:
+        workflows = _import_modules(
+            "workflows",
+            unpacked_file_name=unpacked_file_name,
+            module_name=module_name,
+            supported_modules=os.getenv("TWC_SUPPORTED_WORKFLOWS").split(","),
+        )
+        activities = _import_modules(
+            "activities",
+            unpacked_file_name=unpacked_file_name,
+            module_name=module_name,
+            supported_modules=os.getenv("TWC_SUPPORTED_ACTIVITIES").split(","),
         )
 
-        worker_opt = WorkerOptions(sentry=sentry)
+        if os.getenv("TWC_TLS_ROOT_CAS").strip() != "":
+            client_config.tls_root_cas = os.getenv("TWC_TLS_ROOT_CAS")
 
-    client = await Client.connect(client_config)
+        if os.getenv("TWC_AUTH_PROVIDER").strip() != "":
+            client_config.auth = AuthOptions(provider=os.getenv("TWC_AUTH_PROVIDER"), config=_get_auth_header())
 
-    worker = Worker(
-        client=client,
-        task_queue=os.getenv("TWC_QUEUE"),
-        workflows=workflows,
-        activities=activities,
-        worker_opt=worker_opt,
-    )
+        if os.getenv("TWC_ENCRYPTION_KEY").strip() != "":
+            client_config.encryption = EncryptionOptions(key=os.getenv("TWC_ENCRYPTION_KEY"), compress=True)
 
-    try:
+        worker_opt = None
+        dsn = os.getenv("TWC_SENTRY_DSN").strip()
+        if dsn != "":
+            sentry = SentryOptions(
+                dsn=dsn,
+                release=os.getenv("TWC_SENTRY_RELEASE").strip() or None,
+                environment=os.getenv("TWC_SENTRY_ENVIRONMENT").strip() or None,
+                redact_params=os.getenv("TWC_SENTRY_REDACT_PARAMS"),
+            )
+
+            worker_opt = WorkerOptions(sentry=sentry)
+
+        client = await Client.connect(client_config)
+
+        worker = Worker(
+            client=client,
+            task_queue=os.getenv("TWC_QUEUE"),
+            workflows=workflows,
+            activities=activities,
+            worker_opt=worker_opt,
+        )
+
         with open("worker_status.txt", "w") as status_file:
             status_file.write("Success")
         await worker.run()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,4 +50,4 @@ async def deploy(ops_test: OpsTest):
         url = await get_application_url(ops_test, application=APP_NAME_SERVER, port=7233)
         await ops_test.model.applications[APP_NAME].set_config({"host": url})
 
-        await attach_worker_resource_file(ops_test)
+        await attach_worker_resource_file(ops_test, rsc_type="workflows")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,5 +24,5 @@ class TestDeployment:
         await run_sample_workflow(ops_test)
 
     async def test_invalid_env_file(self, ops_test: OpsTest):
-        """Connects a client and runs a basic Temporal workflow."""
+        """Attaches an invalid .env file to the worker."""
         await attach_worker_resource_file(ops_test, rsc_type="env-file")

--- a/tox.ini
+++ b/tox.ini
@@ -97,11 +97,12 @@ deps =
     ipdb==0.13.9
     juju==3.2.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
-    temporal-lib-py==1.1.2
+    pytest-operator==0.31.1
+    temporal-lib-py==1.3.1
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_charm.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
 
 [testenv:integration-scaling]
 description = Run scaling integration tests
@@ -109,11 +110,12 @@ deps =
     ipdb==0.13.9
     juju==3.2.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
-    temporal-lib-py==1.1.2
+    pytest-operator==0.31.1
+    temporal-lib-py==1.3.1
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_scaling.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode
 
 [testenv:integration-upgrades]
 description = Run upgrades integration tests
@@ -121,8 +123,9 @@ deps =
     ipdb==0.13.9
     juju==3.2.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
-    temporal-lib-py==1.1.2
+    pytest-operator==0.31.1
+    temporal-lib-py==1.3.1
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest {[vars]tst_path}integration/test_upgrades.py -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode


### PR DESCRIPTION
This PR addresses the following:

- Adds a handler to reapply the pebble plan after a restart with the `pebble-ready` event to address this [bug](https://warthogs.atlassian.net/browse/CSS-6875) (See this [PR](https://github.com/canonical/superset-k8s-operator/pull/28) for reference).
- Adds a workload container health check using `exec`, which checks if the Temporal worker is running or not.