### PR TITLE
Unpin 'protobuf' version and add better worker error logging.

### DIFF
--- a/src/resources/check_status.py
+++ b/src/resources/check_status.py
@@ -18,10 +18,10 @@ def check_worker_status():
             status = status_file.read().strip()
             logger.info(f"Async status: {status}")
 
-        if "Error" in status:
-            exit_code = 1
-        else:
+        if status.startswith("Success"):
             exit_code = 0
+        else:
+            exit_code = 1
     except FileNotFoundError:
         logger.error("Status file not found. Worker is not running.")
         exit_code = 1

--- a/src/resources/worker-dependencies.txt
+++ b/src/resources/worker-dependencies.txt
@@ -1,3 +1,2 @@
 temporal-lib-py==1.1.3
-protobuf==3.20.0
 wheel==0.41.2

--- a/src/resources/worker.py
+++ b/src/resources/worker.py
@@ -8,8 +8,10 @@
 import asyncio
 import glob
 import inspect
+import logging
 import os
 import sys
+import traceback
 from importlib import import_module
 
 from temporallib.auth import (
@@ -21,6 +23,9 @@ from temporallib.auth import (
 from temporallib.client import Client, Options
 from temporallib.encryption import EncryptionOptions
 from temporallib.worker import SentryOptions, Worker, WorkerOptions
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_auth_header():
@@ -156,7 +161,8 @@ async def run_worker(unpacked_file_name, module_name):
     except Exception as e:
         # If an error occurs, write the error message to the status file
         with open("worker_status.txt", "w") as status_file:
-            status_file.write(f"Error: {e}")
+            logger.exception("Error in the workflow:")
+            traceback.print_exception(type(e), e, e.__traceback__, file=status_file)
 
 
 if __name__ == "__main__":  # pragma: nocover


### PR DESCRIPTION
Changes:

1. `protobuf==3.2.0` conflicted with the dependencies of a package I needed for my workflow. I unpinned it. @kelkawi-a was there a reason you pinned it to that version? Should we pin it to something else that is compatible?
2. Error message itself in `worker_status.txt` was not good enough to debug my issues. I changed it to print the whole stack trace, so we get exact lines of code to look at.

PS. I did not want to deal with `tox`, fingers crossed that this passes the checks.