### PR TITLE
Add proxy instructions to README and update Vault integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,5 +1,9 @@
 name: Integration tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
 
@@ -10,6 +14,6 @@ jobs:
     with:
       channel: 1.25-strict/stable
       modules: '["test_charm.py", "test_scaling.py", "test_vault.py"]'
-      juju-channel: 3.1/stable
+      juju-channel: 3.3/stable
       self-hosted-runner: false
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ container.
 ### Adding Environment Variables
 
 The Temporal Worker operator can be used to inject environment variables that
-can be ingested by your workflows. This can be done using the Juju command line as follows:
+can be ingested by your workflows. This can be done using the Juju command line
+as follows:
 
 ```bash
 juju attach-resource temporal-worker-k8s env-file=path/to/.env
@@ -84,6 +85,22 @@ To run a basic workflow, you may use a simple client (e.g.
 [sdk-python sample](https://github.com/temporalio/sdk-python#quick-start)) and
 connect to the same Temporal server. If run on the same namespace and task queue
 as the Temporal Worker, it should be executed successfully.
+
+## Enable Proxy
+
+To enable the Temporal worker charm to use an HTTP proxy, the following Juju
+model configurations can be set. The charm will read these values and set the
+`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment in the workload container
+respectively.
+
+```bash
+juju model-config juju-http-proxy="<http_proxy>"
+juju model-config juju-https-proxy="<https_proxy>"
+juju model-config juju-no-proxy="<no_proxy>"
+```
+
+A config change may be needed if your charm is already deployed to force the
+charm to re-initialize.
 
 ## Scaling
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ secrets in Vault.
 
 **Note**: At the time of writing, the Vault operator charm currently has
 compatibility issues with some versions of Juju (e.g. Juju `v3.2.4`). It has
-been tested successfully with Juju `v3.1.8`.
+been tested successfully with Juju `v3.3.5`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ secrets in Vault.
 
 **Note**: At the time of writing, the Vault operator charm currently has
 compatibility issues with some versions of Juju (e.g. Juju `v3.2.4`). It has
-been tested successfully with Juju `v3.3.5`.
+been tested successfully with Juju
+[`v3.3.5`](https://github.com/canonical/temporal-worker-k8s-operator/actions/runs/9874524137/job/27269330380).
 
 ## Contributing
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,7 +202,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             if self.unit.is_leader():
                 self._state.env = env
         except ModelError as err:
-            logger.error(err)
+            logger.debug(f"env-file resource not found {err}")
 
     def _check_required_config(self, config_list):
         """Check if required config has been set by user.

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,7 +202,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             if self.unit.is_leader():
                 self._state.env = env
         except ModelError as err:
-            logger.debug(f"env-file resource not found {err}")
+            logger.debug("env-file resource not found %s", err)
 
     def _check_required_config(self, config_list):
         """Check if required config has been set by user.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -278,7 +278,7 @@ async def wait_for_vault_status_message(
 
 
 async def authorize_charm(ops_test: OpsTest, root_token: str):
-    """Authorize the charm by executing the 'authorize-charm' action on the leader unit.
+    """Authorize the Vault charm by executing the 'authorize-charm' action on the leader unit.
 
     Args:
         ops_test: Ops test Framework.
@@ -289,10 +289,13 @@ async def authorize_charm(ops_test: OpsTest, root_token: str):
     """
     assert ops_test.model
     leader_unit = await get_leader_unit(ops_test.model, "vault-k8s")
+    secret = await ops_test.model.add_secret("approle-token-vault-k8s", [f"token={root_token}"])
+    secret_id = secret.split(":")[-1]
+    await ops_test.model.grant_secret("approle-token-vault-k8s", "vault-k8s")
     authorize_action = await leader_unit.run_action(
         action_name="authorize-charm",
         **{
-            "token": root_token,
+            "secret-id": secret_id,
         },
     )
     result = await ops_test.model.get_action_output(action_uuid=authorize_action.entity_id, wait=120)

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.2.0.1
+    juju==3.3.0.0
     pytest==7.1.3
     pytest-operator==0.31.1
     temporal-lib-py==1.3.1
@@ -113,7 +113,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.2.0.1
+    juju==3.3.0.0
     pytest==7.1.3
     pytest-operator==0.31.1
     temporal-lib-py==1.3.1


### PR DESCRIPTION
This PR:
- Adds instructions to the README for enabling proxy.
- Updates the Vault integration tests to reflect the changes made in [this PR](https://github.com/canonical/vault-k8s-operator/pull/413). This introduced the use of Juju secrets, which means the integration tests must now run on Juju 3.3.