### PR TITLE
Update the documentation for the charm environmental file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@8892eb826818585b397295e40276ddd0c5d3d459
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@52b5f6b34e554b89b987112a78f012d04c0a54ec
     secrets: inherit

--- a/config.yaml
+++ b/config.yaml
@@ -171,31 +171,30 @@ options:
       Sample structure:
     
         ```yaml
-          environment:
-            env:
-              - name: key1
-                value: value1
-              - name: nested_example_key
-                value: 
-                  - connection_id: a_connection_id
-                    unnesting:
-                      tables:
-                        issues: ["test1", "test2"]
-                        users: [test3]
-                    redaction:
-            juju:
-              - secret-id: <secret_id>
-                name: sensitive1
-                key: key1
-              - secret-id: <secret_id>
-                name: sensitive2
-                key: key2
-            vault:
-              - path: my-secrets
-                name: sensitive1
-                key: key1
-              - path: my-secrets
-                name: sensitive2
-                key: key2
+          env:
+            - name: key1
+              value: value1
+            - name: nested_example_key
+              value: 
+                - connection_id: a_connection_id
+                  unnesting:
+                    tables:
+                      issues: ["test1", "test2"]
+                      users: [test3]
+                  redaction:
+          juju:
+            - secret-id: <secret_id>
+              name: sensitive1
+              key: key1
+            - secret-id: <secret_id>
+              name: sensitive2
+              key: key2
+          vault:
+            - path: my-secrets
+              name: sensitive1
+              key: key1
+            - path: my-secrets
+              name: sensitive2
+              key: key2
         ```
     type: string

--- a/src/environment_processors.py
+++ b/src/environment_processors.py
@@ -123,7 +123,7 @@ def process_vault_variables(charm, parsed_environment_data):
 def parse_environment(yaml_string):
     """Parse a YAML string containing environment variables and validates its structure.
 
-    The YAML string should contain an 'environment' key with nested 'env', 'juju', and 'vault' keys.
+    The YAML string may contain 'env', 'juju', and 'vault' keys as required.
     Each nested key should follow a specific structure:
         - 'env': A list of dictionaries with 'name' and 'value' keys.
         - 'juju': A list of dictionaries with 'secret-id', 'name', and 'key' keys.


### PR DESCRIPTION
The config option `environment` has an invalid sample file in the description. 

this updates the documentation to match changes introduced in https://github.com/canonical/temporal-worker-k8s-operator/pull/25