### PR TITLE
allow the config options of the temporal connection to be overridden by juju and vault secrets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@8892eb826818585b397295e40276ddd0c5d3d459
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@52b5f6b34e554b89b987112a78f012d04c0a54ec
     secrets: inherit

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -240,6 +240,12 @@ class TestCharm(TestCase):
                 - secret-id: {secret_id}
                   name: sensitive2
                   key: key2
+                - secret-id: {secret_id}
+                  name: TEMPORAL_ENCRYPTION_KEY
+                  key: encryption-key
+                - secret-id: {secret_id}
+                  name: TWC_SENTRY_DSN
+                  key: sentry-dns
             vault:
                 - path: secrets
                   name: access_token
@@ -247,7 +253,6 @@ class TestCharm(TestCase):
         """
         )
         harness.update_config({"environment": environment_config})
-
         want_plan = {
             "services": {
                 "temporal-worker": {
@@ -265,6 +270,8 @@ class TestCharm(TestCase):
                             "sensitive2": "world",
                             "access_token": "token_secret",
                             "test_nested": '[{"connection_id": "my_connection_id", "unnesting": {"tables": {"table1": ["col1", "col2"], "table2": ["col3"]}}, "redaction": null}]',
+                            "TEMPORAL_ENCRYPTION_KEY": "temporal-encryption-value",
+                            "TWC_SENTRY_DSN": "temporal-encryption-value",
                         },
                     },
                 }
@@ -394,7 +401,12 @@ def simulate_lifecycle(harness, config):
 
     secret_id = harness.add_model_secret(
         "temporal-worker-k8s",
-        {"key1": "hello", "key2": "world"},
+        {
+            "key1": "hello",
+            "key2": "world",
+            "encryption-key": "temporal-encryption-value",
+            "sentry-dns": "temporal-encryption-value",
+        },
     )
 
     return secret_id


### PR DESCRIPTION
With the current setup of the charm the config options i.e TEMPORAL_ENCRYPTION_KEY cannot be overridden by the value store in the vault or juju secrets. it always defaults to the value set on the charm even after is has been defined in a juju secret or a vault.

This change adds a check for the already defined environmental variables in the context to avoid the `convert_env_var` setting the `TWC_` and `TEMPORAL_` prefix variable from being set to empty. see the test for the example.

fixes #36 