### PR TITLE
Improve juju secrets handling

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
-# TODO (kelkawi-a): remove these once pebble CVE resolution propagates down the pipeline
-CVE-2024-45338
+# TODO (kelkawi-a): remove these once temporal propagates the fix to their SDK
+CVE-2025-29787

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ secret and grant the charm access to it:
 ```bash
 juju add-secret my-secret key1=value1 key2=value2
 
-# Output: secret:<secret_id>
+# Output: secret:<secret_id1>
 
 juju grant-secret my-secret temporal-worker-k8s
 ```
@@ -118,12 +118,13 @@ The environment variables can then be configured into the charm as follows:
 
 ```yaml
 juju:
-  - secret-id: <secret_id>
+  - secret-id: <secret_id1>
     name: env_var1
     key: key1
-  - secret-id: <secret_id>
+  - secret-id: <secret_id1>
     name: env_var2
     key: key2
+  - secret-id: <secret_id2> # reads all keys from this secret
 ```
 
 #### Vault

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ env:
     value: value1
   - name: key2
     value: value2
+  - name: key3-example
+    value: value3
 ```
 
 #### Juju User Secrets (Requires Juju 3.3+)
@@ -126,6 +128,11 @@ juju:
     key: key2
   - secret-id: <secret_id2> # reads all keys from this secret
 ```
+
+When providing only a secret ID, the charm will read all keys from this secret,
+and inject them into the workload container with `SCREAMING_SNAKE_CASE` (i.e. if
+the key is `access-token`, it will be available in the workload container as the
+`ACCESS_TOKEN` environment variable).
 
 #### Vault
 

--- a/config.yaml
+++ b/config.yaml
@@ -183,12 +183,13 @@ options:
                       users: [test3]
                   redaction:
           juju:
-            - secret-id: <secret_id>
+            - secret-id: <secret_id1>
               name: sensitive1
               key: key1
-            - secret-id: <secret_id>
+            - secret-id: <secret_id1>
               name: sensitive2
               key: key2
+            - secret-id: <secret_id2> # reads all keys from this secret
           vault:
             - path: my-secrets
               name: sensitive1

--- a/src/environment_processors.py
+++ b/src/environment_processors.py
@@ -157,9 +157,8 @@ def parse_environment(yaml_string):
     if not isinstance(env, list) or not all(
         isinstance(item, dict) and "name" in item and "value" in item and len(item) == 2 for item in env
     ):
-        raise ValueError(
-            "Invalid environment structure: 'env' should be a list of dictionaries with 'name' and 'value'"
-        )
+        logging.debug("Invalid environment structure: 'env' should be a list of dictionaries with 'name' and 'value'")
+        raise ValueError("Invalid environment structure. Check logs")
 
     # Validate juju key
     juju = data.get("juju", [])
@@ -168,9 +167,10 @@ def parse_environment(yaml_string):
         and ((set(item.keys()) == {"secret-id"}) or (set(item.keys()) == {"secret-id", "name", "key"}))
         for item in juju
     ):
-        raise ValueError(
+        logging.debug(
             "Invalid environment structure: each item in 'juju' must either contain only 'secret-id' or all of 'secret-id', 'name', and 'key'"
         )
+        raise ValueError("Invalid environment structure. Check logs")
 
     # Validate vault key
     vault = data.get("vault", [])
@@ -178,9 +178,10 @@ def parse_environment(yaml_string):
         isinstance(item, dict) and "path" in item and "name" in item and "key" in item and len(item) == 3
         for item in vault
     ):
-        raise ValueError(
+        logging.debug(
             "Invalid environment structure: 'vault' should be a list of dictionaries with 'path', 'name', and 'key'"
         )
+        raise ValueError("Invalid environment structure. Check logs")
 
     parsed_data = {
         "env": [{"name": item.get("name"), "value": item.get("value")} for item in env],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -154,9 +154,7 @@ class TestCharm(TestCase):
         harness.update_config({"environment": invalid_environment_config_env})
         self.assertEqual(
             harness.model.unit.status,
-            BlockedStatus(
-                "Invalid environment structure: 'env' should be a list of dictionaries with 'name' and 'value'"
-            ),
+            BlockedStatus("Invalid environment structure. Check logs"),
         )
 
         invalid_environment_config_juju = dedent(
@@ -170,9 +168,7 @@ class TestCharm(TestCase):
         harness.update_config({"environment": invalid_environment_config_juju})
         self.assertEqual(
             harness.model.unit.status,
-            BlockedStatus(
-                "Invalid environment structure: each item in 'juju' must either contain only 'secret-id' or all of 'secret-id', 'name', and 'key'"
-            ),
+            BlockedStatus("Invalid environment structure. Check logs"),
         )
 
         invalid_environment_config_vault = dedent(
@@ -186,9 +182,7 @@ class TestCharm(TestCase):
         harness.update_config({"environment": invalid_environment_config_vault})
         self.assertEqual(
             harness.model.unit.status,
-            BlockedStatus(
-                "Invalid environment structure: 'vault' should be a list of dictionaries with 'path', 'name', and 'key'"
-            ),
+            BlockedStatus("Invalid environment structure. Check logs"),
         )
 
     @mock.patch("ops.jujuversion.JujuVersion.from_environ")


### PR DESCRIPTION
This PR improves the way juju secrets are handled to make it less cumbersome to configure the worker charm. Previously, operators would have to configure the charm to read each key as follows:

```yaml
env:
    juju:
        - secret-id: {secret_id}
          name: ACCESS_TOKEN
          key: access-token
        - secret-id: {secret_id}
          name: CLIENT_SECRET
          key: client-secret
```

However, this approach can quickly become unscalable. This PR now allows operators to simply specify the secret ID as follows:

```yaml
env:
    juju:
        - secret-id: {secret_id}
```

The charm will then read all the key/value pairs in this secret, convert them into environment variables and inject them into the workload container.