### PR TITLE
Add support for workload metrics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
   # An example config option to customise the log level of the workload
   log-level:
     description: |
-      Configures the log level of gunicorn. 
+      Configures the log level of gunicorn.
 
       Acceptable values are: "info", "debug", "warning", "error" and "critical"
     default: "info"
@@ -53,9 +53,9 @@ options:
 
   sentry-sample-rate:
     description: |
-      A value between 0 (0% of errors) and 1 (100% of errors) to indicate the proportion of errors 
+      A value between 0 (0% of errors) and 1 (100% of errors) to indicate the proportion of errors
       to be captured by Sentry.
-    
+
     default: 1.0
     type: float
 
@@ -73,7 +73,7 @@ options:
   auth-provider:
     description: |
       (Deprecated in favor of 'auth-secret-id') Authentication provider for user authentication.
-    
+
       Acceptable values are "candid" and "google".
     default: ""
     type: string
@@ -158,30 +158,34 @@ options:
     default: ""
     type: string
 
+  workload-prometheus-port:
+    description: Port of the workload defined metrics endpoint.
+    type: int
+
   environment:
     description: |
-      This configuration is used to manage and retrieve sensitive information required 
-      by the application from different sources. The `environment` configuration supports 
+      This configuration is used to manage and retrieve sensitive information required
+      by the application from different sources. The `environment` configuration supports
       the following sources:
-      
+
       - **Environment Variables**: Plaintext environment variables.
       - **Juju**: Secrets can be managed and retrieved using Juju's secret storage capabilities.
       - **Vault**: Secrets can be securely stored and accessed from a HashiCorp Vault instance.
-      
-      The application will prioritize these sources in the following order: Vault, Juju, 
-      and then environment variables. If a variable is not found in the higher priority 
-      sources, it will fallback to the next available source. This ensures that the 
-      application can function correctly in various deployment scenarios while maintaining 
+
+      The application will prioritize these sources in the following order: Vault, Juju,
+      and then environment variables. If a variable is not found in the higher priority
+      sources, it will fallback to the next available source. This ensures that the
+      application can function correctly in various deployment scenarios while maintaining
       security and flexibility.
 
       Sample structure:
-    
+
         ```yaml
           env:
             - name: key1
               value: value1
             - name: nested_example_key
-              value: 
+              value:
                 - connection_id: a_connection_id
                   unnesting:
                     tables:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,11 +9,11 @@ display-name: Temporal Worker
 summary: Temporal Worker operator
 description: |
   Temporal is a developer-first, open source platform that ensures
-  the successful execution of services and applications (using workflows). 
-  
-  This charm provides the Temporal worker which can connect to the Temporal 
+  the successful execution of services and applications (using workflows).
+
+  This charm provides the Temporal worker which can connect to the Temporal
   server via https to execute workflows.
-maintainers: 
+maintainers:
   - Commercial Systems <jaas-crew@lists.canonical.com>
 source: https://github.com/canonical/temporal-worker-k8s-operator
 docs: https://github.com/canonical/temporal-worker-k8s-operator
@@ -51,6 +51,8 @@ provides:
     interface: prometheus_scrape
   grafana-dashboard:
     interface: grafana_dashboard
+  workload-metrics-endpoint:
+    interface: prometheus_scrape
 
 requires:
   logging:

--- a/src/charm.py
+++ b/src/charm.py
@@ -81,6 +81,15 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             refresh_event=self.on.config_changed,
         )
 
+        if self.config.get("workload-prometheus-port"):
+            WORKLOAD_PROMETHEUS_PORT = self.config.get("workload-prometheus-port")
+            self._app_prometheus_scraping = MetricsEndpointProvider(
+                self,
+                relation_name="workload-metrics-endpoint",
+                jobs=[{"static_configs": [{"targets": [f"*:{WORKLOAD_PROMETHEUS_PORT}"]}]}],
+                refresh_event=self.on.config_changed,
+            )
+
         # Loki
         self._log_forwarder = LogForwarder(self, relation_name="logging")
 


### PR DESCRIPTION
Currently, Temporal worker charm only supports metrics endpoint for Temporal SDK metrics, it does not support application defined metrics endpoint.

To enable application metrics, this PR adds a relation for workload metrics endpoint.

