### PR TITLE
ci: add jira sync configuration

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,29 @@
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "WF"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: Done
+
+  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+  # If not specified, all issues will be synchronized
+  labels:
+    - bug
+    - enhancement
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: true
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: false
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story
+    bug: Bug


### PR DESCRIPTION
This configuration will allow the sync between this repository and the team's Jira project for automatically adding Jira tasks/bugs to the backlog of the project.

Example implementations:

* A bug converted into a Jira bug https://github.com/canonical/temporal-k8s-operator/issues/63
* An enhancement converted into a Jira story https://github.com/canonical/temporal-k8s-operator/issues/48