### PR TITLE
ci: fix incorrect workflow name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-charm:
-    uses: ./.github/workflows/integration_tests.yaml
+    uses: ./.github/workflows/integration_test.yaml
 
   release-charm:
     name: Release the charm


### PR DESCRIPTION
The ci.yaml uses integration_test.yaml instead of integration_tests.yaml