### PR TITLE
ci: add a PR template that should be the standard for all WF repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description
+<!-- Summary of the changes in this PR -->
+
+<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
+
+---
+## Testing instructions
+<!-- Steps to manually test the changes and the expected results, only if applicable -->
+<!-- Example:
+1. Build charm
+2. Configure X with abc value
+3. Integrate with Y charm
+-->
+
+## Notes for Reviewers (optional)
+<!-- Any specific areas to focus on, known issues, or extra context -->
+
+---
+## Checklist (all that apply)
+- [ ] Unit tests added or updated
+- [ ] Integration tests added or updated
+- [ ] Documentation updated


### PR DESCRIPTION
This minimal PR template requests relevant information such as description, manual testing instructions (if applicable), notes for reviewers, and what issue the PR is solving, as well as a small checklist for ensuring contributors are reminded of adding unit/integration tests and document updates, if needed.