### PR TITLE
ci: upload rock as artefact and do not fail on trivy scans

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,9 +12,12 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
+    env:
+      TRIVY_EXIT_CODE: '0'
     with:
       channel: 1.25-strict/stable
       modules: '["test_charm.py", "test_scaling.py", "test_vault.py", "test_postgres_db.py"]'
       juju-channel: 3.6/stable
       self-hosted-runner: false
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
+      upload-image: "artifact"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: dnplas/operator-workflows/.github/workflows/integration_test.yaml@dnplas-trivy-exit-code-as-input
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       channel: 1.25-strict/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,10 +10,8 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: dnplas/operator-workflows/.github/workflows/integration_test.yaml@dnplas-trivy-exit-code-as-input
     secrets: inherit
-    env:
-      TRIVY_EXIT_CODE: '0'
     with:
       channel: 1.25-strict/stable
       modules: '["test_charm.py", "test_scaling.py", "test_vault.py", "test_postgres_db.py"]'
@@ -21,3 +19,4 @@ jobs:
       self-hosted-runner: false
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
       upload-image: "artifact"
+      trivy-exit-code: '0'


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

This commit ensures the sample rock in this repository is not published to the GHCR registry as it is not supported by the team, its only purpose is to serve as an example and to be used in tests.
This commit also prevents the automatic trivy scans to exit with status code 1, which was causing the CI to fail. While it is okay to scan the image, since this is not a production or supported rock, we don't mind too much about the scan results.

Fixes #49


---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

Look out for the CI to upload the rock instead of publishing to GHCR.

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
