### PR TITLE
ci (backport): upload rock as artefact and do not fail on trivy scans

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,3 +18,5 @@ jobs:
       juju-channel: 3.6/stable
       self-hosted-runner: false
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
+      upload-image: "artifact"
+      trivy-exit-code: '0'


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

* ci: upload rock as artefact and do not fail on trivy scans

This commit ensures the sample rock in this repository is not published to the GHCR registry as it is not supported by the team, its only purpose is to serve as an example and to be used in tests.
This commit also prevents the automatic trivy scans to exit with status code 1, which was causing the CI to fail. While it is okay to scan the image, since this is not a production or supported rock, we don't mind too much about the scan results.

Fixes #49

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

No manual testing required, just see the CI is green.

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
