### PR TITLE
[WF-117,WF-120] Specify python image as upstream-source + handle failing pebble replan appropriately

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -45,6 +45,7 @@ resources:
   temporal-worker-image:
     type: oci-image
     description: OCI image containing Temporal worker definition.
+    upstream-source: python:3.13.7-slim-trixie  # use debian based image, ubuntu/python is a chiselled image
 
 provides:
   metrics-endpoint:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -45,7 +45,7 @@ resources:
   temporal-worker-image:
     type: oci-image
     description: OCI image containing Temporal worker definition.
-    upstream-source: python:3.13.7-slim-trixie  # use debian based image, ubuntu/python is a chiselled image
+    upstream-source: ubuntu/python:3.12-24.04_stable
 
 provides:
   metrics-endpoint:

--- a/resource_sample_py/README.md
+++ b/resource_sample_py/README.md
@@ -5,7 +5,7 @@ This is a sample
 that can be used to build Python-based Temporal workflows.
 
 To work with the charm, the root directory must include a
-`scripts/start-worker.sh` file, with a command that would start your
+`/app/scripts/start-worker.sh` file, with a command that would start your
 asynchronous Temporal worker.
 
 To test the worker locally, export the relevant environment variables found in

--- a/resource_sample_py/rockcraft.yaml
+++ b/resource_sample_py/rockcraft.yaml
@@ -13,7 +13,7 @@ services:
     override: replace
     summary: "temporal worker"
     startup: disabled
-    command: "./app/scripts/start-worker.sh"
+    command: "/app/scripts/start-worker.sh"
     environment:
       TEMPORAL_HOST: localhost:7233
       TEMPORAL_NAMESPACE: default

--- a/resource_sample_py/scripts/start-worker.sh
+++ b/resource_sample_py/scripts/start-worker.sh
@@ -3,4 +3,4 @@
 # See LICENSE file for licensing details.
 
 # update 'resource_sample' accordingly
-python3 app/resource_sample/worker.py
+python3 /app/resource_sample/worker.py

--- a/src/charm.py
+++ b/src/charm.py
@@ -320,6 +320,13 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             self.unit.status = WaitingStatus("waiting for pebble api")
             return
 
+        if not container.exists("/app/scripts/start-worker.sh"):
+            logger.error(
+                "The workload container does not have the expected entrypoint script. Please refresh the charm with another valid image"
+            )
+            self.unit.status = BlockedStatus("Please refresh the charm with a valid worker image")
+            return
+
         context = {}
         auth_config = {}
         try:
@@ -385,7 +392,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             "services": {
                 self.name: {
                     "summary": "temporal worker",
-                    "command": "./app/scripts/start-worker.sh",
+                    "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": context,
@@ -394,7 +401,15 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         }
 
         container.add_layer(self.name, pebble_layer, combine=True)
-        container.replan()
+
+        try:
+            container.replan()
+        except pebble.ChangeError as e:
+            logger.exception(f"Failed to replan pebble services: {e}")
+            self.unit.status = BlockedStatus(
+                "Failed to start pebble services - please consult logs for further details"
+            )
+            return
 
         self.unit.status = MaintenanceStatus("replanning application")
 

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,7 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import datetime
 import json
+import unittest.mock
 
 import ops.testing
 import pytest
@@ -23,6 +25,31 @@ def pytest_configure(config):  # noqa: DCO020
 @pytest.fixture
 def temporal_worker_k8s_charm(monkeypatch):
     yield TemporalWorkerK8SOperatorCharm
+
+
+@pytest.fixture(autouse=True)
+def global_patches():
+    with unittest.mock.patch("ops.Container.exists", return_value=True) as mock_exists:
+        yield mock_exists
+
+
+@pytest.fixture(scope="function")
+def pebble_change_error():
+    return ops.pebble.ChangeError(
+        err="test-change-error",
+        change=ops.pebble.Change(
+            id=ops.pebble.ChangeID("test-id"),
+            kind="test",
+            summary="test change error",
+            status="none",
+            tasks=[],
+            ready=True,
+            err=None,
+            spawn_time=datetime.datetime.now(),
+            ready_time=None,
+            data={},
+        ),
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -179,6 +179,23 @@ def test_blocked_on_missing_host(context, state):
     assert state_out.unit_status == ops.BlockedStatus("Invalid config: host value missing")
 
 
+def test_image_without_entrypoint(context, state, temporal_worker_container):
+    with unittest.mock.patch("ops.Container.exists", return_value=False):
+        state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+
+    assert state_out.unit_status == ops.BlockedStatus("Please refresh the charm with a valid worker image")
+
+
+def test_error_replanning_pebble_plan(context, state, temporal_worker_container, pebble_change_error):
+    with unittest.mock.patch("ops.Container.replan", side_effect=pebble_change_error):
+        state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+        state_out = context.run(context.on.config_changed(), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        "Failed to start pebble services - please consult logs for further details"
+    )
+
+
 def test_ready(context, state, temporal_worker_container, namespace, queue):
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
@@ -188,7 +205,7 @@ def test_ready(context, state, temporal_worker_container, namespace, queue):
             "services": {
                 "temporal-worker": {
                     "summary": "temporal worker",
-                    "command": "./app/scripts/start-worker.sh",
+                    "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": WANT_ENV,
@@ -249,7 +266,7 @@ def test_auth_juju_secret(
             "services": {
                 "temporal-worker": {
                     "summary": "temporal worker",
-                    "command": "./app/scripts/start-worker.sh",
+                    "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": expected_env,
@@ -278,7 +295,7 @@ def test_vault_relation(context, state, temporal_worker_container):
             "services": {
                 "temporal-worker": {
                     "summary": "temporal worker",
-                    "command": "./app/scripts/start-worker.sh",
+                    "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": WANT_ENV,
@@ -396,7 +413,7 @@ def test_valid_environment_config(context, state, temporal_worker_container, con
                 "services": {
                     "temporal-worker": {
                         "summary": "temporal worker",
-                        "command": "./app/scripts/start-worker.sh",
+                        "command": "/app/scripts/start-worker.sh",
                         "startup": "enabled",
                         "override": "replace",
                         "environment": {
@@ -441,7 +458,7 @@ def test_db_relation(context, state, temporal_worker_container):
             "services": {
                 "temporal-worker": {
                     "summary": "temporal worker",
-                    "command": "./app/scripts/start-worker.sh",
+                    "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": {


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
- We are not specifying an `upstream-source` for the worker image resource. If a charm specifies an image resource for a workload container, an image must be presented during charm release. The CI to release charm fails since we do not specify one.

To resolve:
1. we specify `python:3.13.7-slim-trixie` as the `upstream-source`. we are unable to use `ubuntu/python` as it is a chiselled image
2. add a check to ensure the charm unit goes into `BlockedStatus` if the workload container does not have the expected entrypoint script

- We are not correctly handling user defined workflows erroring when pebble starts up the worker process. This results in the unit going into `ErrorStatus`, making it a pain to clean up the units.

To resolve:
1. we add exception handling when replanning pebble services to move the unit into `BlockedStatus` to indicate an issue with the provided image. logs may be explored to determine root cause

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #69 + Closes #46 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
4. Configure X with abc value
5. Integrate with Y charm
-->
Added unit tests: `tox -e unit`

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
Manually tested a faulty workload image -> can add an integration test if a good idea

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
