### PR TITLE
ci: add 60-minute test-timeout to integration-tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,3 +25,4 @@ jobs:
       upload-image: "artifact"
       trivy-exit-code: '0'
       pre-run-script: .github/scripts/setup-artifact-import.sh
+      test-timeout: 60

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: arjun11-malik/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       provider: k8s

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,4 +25,4 @@ jobs:
       upload-image: "artifact"
       trivy-exit-code: '0'
       pre-run-script: .github/scripts/setup-artifact-import.sh
-      test-timeout: 60
+      test-timeout: 35


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
add test-timeout (60m) to integration-tests to prevent long-running jobs
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
