### PR TITLE
[WF-139] Test with deployment from 1.0/edge

### DIFF
--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,3 +1,3 @@
 model   = "terraform"
 image   = { "image" : "docker://localhost:5000/temporal-worker:test-terraform" }
-channel = "latest/edge" # TODO: update to 1.0/edge once channel published (https://github.com/canonical/temporal-worker-k8s-operator/issues/74)
+channel = "1.0/edge"


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Since `1.0/edge` channel is published, we should test our terraform module with deployments from this channel instead of `latest/edge`

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #74 

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
cd terraform && just test

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
