### PR TITLE
[WF-203] Use juju provider v1.0.0

### DIFF
--- a/terraform/justfile
+++ b/terraform/justfile
@@ -38,7 +38,10 @@ destroy-model:
 
 [private]
 add-model: (destroy-model)
+    #!/usr/bin/bash
     juju add-model terraform
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    sed -i "s|model_uuid = \".*\"|model_uuid = \"${MODEL_UUID}\"|" test/test.tfvars
 
 # Run terraform format
 fmt: (initialize)

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -67,9 +67,11 @@ apply variables_file: (initialize)
 
 # Destroy the terraform plan with the provided variables file
 destroy variables_file:
+    #!/usr/bin/bash
     terraform destroy -auto-approve -var-file="${variables_file}"
 
     just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
 
 test: (build-and-push-image)
     #!/usr/bin/bash

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -38,7 +38,20 @@ destroy-model:
 
 [private]
 add-model: (destroy-model)
+    #!/usr/bin/bash
     juju add-model terraform
+
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "./test/test.tfvars"
+
+[private]
+validate_test_tfvars variables_file="test/test.tfvars":
+    #!/usr/bin/bash
+    MODEL_UUID=$(grep '^model_uuid' "${variables_file}" | awk -F '"' '{print $2}')
+
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
 
 # Run terraform format
 fmt: (initialize)
@@ -70,6 +83,8 @@ test: (build-and-push-image)
 
     just add-model
 
+    just validate_test_tfvars "./test/test.tfvars"
+    
     just apply "./test/test.tfvars"
 
     juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -40,8 +40,18 @@ destroy-model:
 add-model: (destroy-model)
     #!/usr/bin/bash
     juju add-model terraform
+
     MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
     sed -i "s|model_uuid = \".*\"|model_uuid = \"${MODEL_UUID}\"|" test/test.tfvars
+
+[private]
+validate_test_tfvars variables_file="test/test.tfvars":
+    #!/usr/bin/bash
+    MODEL_UUID=$(grep '^model_uuid' "${variables_file}" | awk -F '"' '{print $2}')
+    
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
 
 # Run terraform format
 fmt: (initialize)
@@ -72,7 +82,7 @@ test: (build-and-push-image)
     trap 'just destroy "./test/test.tfvars"' EXIT
 
     just add-model
-
+    just validate_test_tfvars "./test/test.tfvars"
     just apply "./test/test.tfvars"
 
     juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -38,20 +38,16 @@ destroy-model:
 
 [private]
 add-model: (destroy-model)
-    #!/usr/bin/bash
     juju add-model terraform
 
-    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
-    echo "model_uuid = \"${MODEL_UUID}\"" >> "./test/test.tfvars"
-
 [private]
-validate_test_tfvars variables_file="test/test.tfvars":
+validate_test_tfvars variables_file:
     #!/usr/bin/bash
-    MODEL_UUID=$(grep '^model_uuid' "${variables_file}" | awk -F '"' '{print $2}')
-
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
     if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
         exit 1
     fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
 
 # Run terraform format
 fmt: (initialize)
@@ -84,7 +80,7 @@ test: (build-and-push-image)
     just add-model
 
     just validate_test_tfvars "./test/test.tfvars"
-    
+
     just apply "./test/test.tfvars"
 
     juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -70,6 +70,6 @@ test: (build-and-push-image)
 
     just add-model
 
-    just apply "./test/test.tfvars" 
+    just apply "./test/test.tfvars"
 
     juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -38,7 +38,6 @@ destroy-model:
 
 [private]
 add-model: (destroy-model)
-    #!/usr/bin/bash
     juju add-model terraform
 
 # Run terraform format
@@ -55,7 +54,7 @@ lint:
 
 # Apply the terraform plan with the provided variables file
 apply variables_file: (initialize)
-    terraform apply -auto-approve -var-file="${variables_file}" 
+    terraform apply -auto-approve -var-file="${variables_file}"
 
 # Destroy the terraform plan with the provided variables file
 destroy variables_file:
@@ -70,7 +69,7 @@ test: (build-and-push-image)
     trap 'just destroy "./test/test.tfvars"' EXIT
 
     just add-model
-    
+
     just apply "./test/test.tfvars" 
 
     juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -41,18 +41,6 @@ add-model: (destroy-model)
     #!/usr/bin/bash
     juju add-model terraform
 
-    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
-    sed -i "s|model_uuid = \".*\"|model_uuid = \"${MODEL_UUID}\"|" test/test.tfvars
-
-[private]
-validate_test_tfvars variables_file="test/test.tfvars":
-    #!/usr/bin/bash
-    MODEL_UUID=$(grep '^model_uuid' "${variables_file}" | awk -F '"' '{print $2}')
-    
-    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
-        exit 1
-    fi
-
 # Run terraform format
 fmt: (initialize)
     terraform fmt
@@ -67,7 +55,7 @@ lint:
 
 # Apply the terraform plan with the provided variables file
 apply variables_file: (initialize)
-    terraform apply -auto-approve -var-file="${variables_file}"
+    terraform apply -auto-approve -var-file="${variables_file}" 
 
 # Destroy the terraform plan with the provided variables file
 destroy variables_file:
@@ -82,7 +70,7 @@ test: (build-and-push-image)
     trap 'just destroy "./test/test.tfvars"' EXIT
 
     just add-model
-    just validate_test_tfvars "./test/test.tfvars"
-    just apply "./test/test.tfvars"
+    
+    just apply "./test/test.tfvars" 
 
     juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,7 @@ resource "null_resource" "attach_image" {
     "password"     = var.image.registry_password,
 })}" > temporal_worker_image.yaml
 
+      juju switch ${var.model}
       juju attach-resource ${var.app_name} temporal-worker-image=temporal_worker_image.yaml
 
       rm temporal_worker_image.yaml

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,12 +24,12 @@ resource "null_resource" "attach_image" {
     "registrypath" = var.image.image,
     "username"     = var.image.registry_username,
     "password"     = var.image.registry_password,
-})}" > temporal_worker_image.yaml
+})}" > ./temporal_worker_image.yaml
 
       juju switch ${var.model}
-      juju attach-resource ${var.app_name} temporal-worker-image=temporal_worker_image.yaml
+      juju attach-resource ${var.app_name} temporal-worker-image=./temporal_worker_image.yaml
 
-      rm temporal_worker_image.yaml
+      rm ./temporal_worker_image.yaml
     EOT
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,11 @@
-data "juju_model" "terraform" {
-  name  = "terraform"
+data "juju_model" "terraform_model" {
+  name  = var.model
   owner = "admin"
 }
 
 resource "juju_application" "temporal_worker_k8s" {
   name = var.app_name
-  model_uuid = data.juju_model.terraform.uuid
+  model_uuid = data.juju_model.terraform_model.uuid
 
   charm {
     name     = "temporal-worker-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "juju_application" "temporal_worker_k8s" {
   name  = var.app_name
-  model = var.model
+  model_uuid = var.model_uuid
 
   charm {
     name     = "temporal-worker-k8s"
@@ -11,31 +11,12 @@ resource "juju_application" "temporal_worker_k8s" {
   constraints = var.constraints
   config      = var.config
 
+  registry_credentials = {
+    "${var.image.image_repository}" = {
+      username = var.image.registry_username
+      password = var.image.registry_password
+    }
+  }
+
   units = var.units
-}
-
-
-resource "null_resource" "attach_image" {
-  provisioner "local-exec" {
-    # Needed since juju_application resource does not support resource map to specify registry creds
-    # Refactor once https://github.com/juju/terraform-provider-juju/issues/620 resolved
-    command = <<EOT
-      echo "${yamlencode({
-    "registrypath" = var.image.image,
-    "username"     = var.image.registry_username,
-    "password"     = var.image.registry_password,
-})}" > ./temporal_worker_image.yaml
-
-      juju switch ${var.model}
-      juju attach-resource ${var.app_name} temporal-worker-image=./temporal_worker_image.yaml
-
-      rm ./temporal_worker_image.yaml
-    EOT
-}
-
-depends_on = [resource.juju_application.temporal_worker_k8s]
-
-triggers = {
-  image = jsonencode(var.image)
-}
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,12 +11,12 @@ resource "juju_application" "temporal_worker_k8s" {
   constraints = var.constraints
   config      = var.config
 
-  registry_credentials = {
-    "${var.image.image_repository}" = {
-      username = var.image.registry_username
-      password = var.image.registry_password
-    }
-  }
+#  registry_credentials = {
+#    "${var.image.image_repository}" = {
+#      username = var.image.registry_username
+#      password = var.image.registry_password
+#    }
+#  }
 
   units = var.units
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,10 @@ resource "juju_application" "temporal_worker_k8s" {
   constraints = var.constraints
   config      = var.config
 
+  resources = {
+    "temporal-worker-image": var.image.image
+  }
+
 #  registry_credentials = {
 #    "${var.image.image_repository}" = {
 #      username = var.image.registry_username

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,12 +15,12 @@ resource "juju_application" "temporal_worker_k8s" {
     "temporal-worker-image" = var.image.image
   } : {}
 
-  #  registry_credentials = {
-  #    "${var.image.image_repository}" = {
-  #      username = var.image.registry_username
-  #      password = var.image.registry_password
-  #    }
-  #  }
+  registry_credentials = {
+      "${var.image.image_repository}" = {
+        username = var.image.registry_username
+        password = var.image.registry_password
+      }
+  }
 
   units = var.units
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,10 @@
 data "juju_model" "terraform" {
-  name = "terraform"
+  name  = "terraform"
   owner = "admin"
 }
 
 resource "juju_application" "temporal_worker_k8s" {
-  name = var.app_name
+  name       = var.app_name
   model_uuid = data.juju_model.terraform.uuid
 
   charm {
@@ -21,10 +21,10 @@ resource "juju_application" "temporal_worker_k8s" {
   } : {}
 
   registry_credentials = {
-      var.image.image_repository = {
-        username = var.image.registry_username
-        password = var.image.registry_password
-      }
+    (var.image.image_repository) = {
+      username = var.image.registry_username
+      password = var.image.registry_password
+    }
   }
 
   units = var.units

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,6 @@
-data "juju_model" "terraform_model" {
-  name  = var.model
-  owner = "admin"
-}
-
 resource "juju_application" "temporal_worker_k8s" {
-  name = var.app_name
-  model_uuid = data.juju_model.terraform_model.uuid
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "temporal-worker-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,11 @@
+data "juju_model" "terraform" {
+  name = "terraform"
+  owner = "admin"
+}
+
 resource "juju_application" "temporal_worker_k8s" {
   name       = var.app_name
-  model_uuid = var.model_uuid
+  model_uuid = data.juju_model.terraform.uuid
 
   charm {
     name     = "temporal-worker-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,7 +21,7 @@ resource "juju_application" "temporal_worker_k8s" {
   } : {}
 
   registry_credentials = {
-      "${var.image.image_repository}" = {
+      var.image.image_repository = {
         username = var.image.registry_username
         password = var.image.registry_password
       }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 resource "juju_application" "temporal_worker_k8s" {
-  name  = var.app_name
+  name       = var.app_name
   model_uuid = var.model_uuid
 
   charm {
@@ -11,16 +11,16 @@ resource "juju_application" "temporal_worker_k8s" {
   constraints = var.constraints
   config      = var.config
 
-  resources = {
-    "temporal-worker-image": var.image.image
-  }
+  resources = var.image.image != "" ? {
+    "temporal-worker-image" = var.image.image
+  } : {}
 
-#  registry_credentials = {
-#    "${var.image.image_repository}" = {
-#      username = var.image.registry_username
-#      password = var.image.registry_password
-#    }
-#  }
+  #  registry_credentials = {
+  #    "${var.image.image_repository}" = {
+  #      username = var.image.registry_username
+  #      password = var.image.registry_password
+  #    }
+  #  }
 
   units = var.units
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ data "juju_model" "terraform" {
 }
 
 resource "juju_application" "temporal_worker_k8s" {
-  name       = var.app_name
+  name = var.app_name
   model_uuid = data.juju_model.terraform.uuid
 
   charm {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,12 +15,12 @@ resource "juju_application" "temporal_worker_k8s" {
     "temporal-worker-image" = var.image.image
   } : {}
 
-  registry_credentials = {
+  registry_credentials = var.image.image_repository != "" ? {
     (var.image.image_repository) = {
       username = var.image.registry_username
       password = var.image.registry_password
     }
-  }
+  } : {}
 
   units = var.units
 }

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,4 +1,4 @@
-model_uuid = "00000000-0000-0000-0000-000000000000"
+model_uuid = "10c66c3e-c119-4600-8ff3-86a0c472b54a"
 image = {
   image = "localhost:5000/temporal-worker:test-terraform"
 }

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,3 +1,4 @@
+model = "terraform"
 image = {
   image = "localhost:5000/temporal-worker:test-terraform"
 }

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,4 +1,3 @@
-model_uuid = "10c66c3e-c119-4600-8ff3-86a0c472b54a"
 image = {
   image = "localhost:5000/temporal-worker:test-terraform"
 }

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,4 +1,3 @@
-model = "terraform"
 image = {
   image = "localhost:5000/temporal-worker:test-terraform"
 }

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,3 +1,5 @@
-model   = "terraform"
-image   = { "image" : "docker://localhost:5000/temporal-worker:test-terraform" }
+model_uuid = "bfa5d336-e42b-437f-825c-cf258fe86b01"
+image = {
+  image = "localhost:5000/temporal-worker:test-terraform"
+}
 channel = "1.0/edge"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,4 +1,4 @@
-model_uuid = "bfa5d336-e42b-437f-825c-cf258fe86b01"
+model_uuid = "00000000-0000-0000-0000-000000000000"
 image = {
   image = "localhost:5000/temporal-worker:test-terraform"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,9 +10,9 @@ variable "units" {
   default     = 1
 }
 
-variable "model" {
-  type = string
-  description = "Juju model where the application is to be deployed"
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
 }
 
 variable "revision" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,6 +10,11 @@ variable "units" {
   default     = 1
 }
 
+variable "model" {
+  type = string
+  description = "Juju model where the application is to be deployed"
+}
+
 variable "revision" {
   type        = number
   description = "Revision of the charm to deploy"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,9 +41,6 @@ variable "image" {
     registry_password = optional(string, "")
   })
   description = "Details of the worker image"
-  default = {
-    image = ""
-  }
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,11 +10,6 @@ variable "units" {
   default     = 1
 }
 
-variable "model_uuid" {
-  type        = string
-  description = "Juju model UUID where the application is to be deployed"
-}
-
 variable "revision" {
   type        = number
   description = "Revision of the charm to deploy"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,9 +10,9 @@ variable "units" {
   default     = 1
 }
 
-variable "model" {
+variable "model_uuid" {
   type        = string
-  description = "Juju model where the application is to be deployed"
+  description = "Juju model UUID where the application is to be deployed"
 }
 
 variable "revision" {
@@ -36,6 +36,7 @@ variable "constraints" {
 variable "image" {
   type = object({
     image             = string
+    image_repository = optional(string, "")
     registry_username = optional(string, "")
     registry_password = optional(string, "")
   })

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,11 +36,14 @@ variable "constraints" {
 variable "image" {
   type = object({
     image             = string
-    image_repository = optional(string, "")
+    image_repository  = optional(string, "")
     registry_username = optional(string, "")
     registry_password = optional(string, "")
   })
   description = "Details of the worker image"
+  default = {
+    image = ""
+  }
 }
 
 variable "config" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.21.1"
+      version = ">= 1.0.0"
     }
 
     null = {


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR updates the Terraform integration for the temporal-ui-k8s-operator to use the new Juju provider v1.0.0, replaces the deprecated model attribute with model_uuid, and removes the need for specifying a model or UUID in the module inputs.

The model UUID is now resolved using the provider’s juju_model data source, ensuring that Terraform always deploys into the correct Juju model without requiring manual configuration or Justfile-injected values.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

## Key-Changes:
- Replace model attribute with `model_uuid`. 
-  New reuired field is `model_uuid = data.juju_model.terraform.uuid` 
- Introduce a `juju_model` data source to resolve model_uuid dynamically.
- Remove obsolete `model` variable declaration from `variables.tf`
- Upgrade provider version to v1.0.0
- `test/test.tfvars` no longer needs to declare `model = "terraform"`
- Removed custom local-exec logic for attaching oci-images and replaced that with juju provider-native resources and registry_credentials fields. 
- This change allows juju provider to manage image resources directly.
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
just validate
just fmt
just lint
just test

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
