### PR TITLE
Update optionality of endpoints in metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -50,12 +50,15 @@ resources:
 provides:
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
 
 requires:
   logging:
     interface: loki_push_api
+    optional: true
     limit: 1
   vault:
     interface: vault-kv


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Updates the optionality of endpoints in the charm metadata, including the providing endpoints (The default value of optional is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional)). This is based on the deployment steps [here](https://charmhub.io/temporal-k8s/docs/t-introduction).

A similar PR has been raised for the server charm: https://github.com/canonical/temporal-k8s-operator/pull/117

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
N/A

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

N/A

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
