### PR TITLE
[WF-144] Fix env precedence over charm config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -329,11 +329,11 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
 
         context = {}
         auth_config = {}
+        charm_config_env = {}
         try:
             self._validate(event)
             if self.config.get("environment"):
                 charm_config_env = self.create_env()
-                context.update(charm_config_env)
             if self.config.get("auth-secret-id"):
                 auth_config = self.get_auth_config_from_juju_secret()
         except ValueError as err:
@@ -368,6 +368,10 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
                 if key not in ["environment", "auth-secret-id"]
             }
         )
+
+        # Environment config (env/juju/vault) should override base charm config values.
+        if charm_config_env:
+            context.update(charm_config_env)
 
         # Auth configs coming from a juju secret take precedence over those coming from config.
         # Auth config options will be deprecated in favor of using juju user secrets.

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -194,6 +194,16 @@ def simple_secret():
 
 
 @pytest.fixture(scope="function")
+def encryption_key_secret():
+    return ops.testing.Secret(
+        owner="app",
+        tracked_content={
+            "encryption-key": "secret-encryption-key",
+        },
+    )
+
+
+@pytest.fixture(scope="function")
 def oidc_auth_secret_content():
     return {
         "auth-provider": "google",

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -144,6 +144,39 @@ WANT_ENV_AUTH = {
 }
 
 
+def _build_environment_config(secret_id: str, include_env: bool = False, include_vault: bool = False) -> str:
+    """Build environment config YAML for encryption-key precedence tests."""
+    env_section = (
+        """
+        env:
+            - name: TEMPORAL_ENCRYPTION_KEY
+              value: env-value
+        """
+        if include_env
+        else ""
+    )
+    vault_section = (
+        """
+        vault:
+            - path: secrets
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: token
+        """
+        if include_vault
+        else ""
+    )
+    return textwrap.dedent(
+        f"""
+        {env_section}
+        juju:
+            - secret-id: {secret_id}
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: encryption-key
+        {vault_section}
+        """
+    )
+
+
 @pytest.fixture
 def all_required_relations(peer_relation, vault_relation, database_relation):
     return [
@@ -436,29 +469,45 @@ def test_valid_environment_config(context, state, temporal_worker_container, con
         )
 
 
-def test_environment_juju_secret_overrides_empty_charm_config(
-    context, state, temporal_worker_container, config, encryption_key_secret, vault_nonce_secret
+@pytest.mark.parametrize(
+    "charm_encryption_key, expected_temporal_key, expected_twc_key",
+    [
+        ("", "secret-encryption-key", ""),
+        ("plaintext-config-key", "secret-encryption-key", "plaintext-config-key"),
+    ],
+    ids=["empty-charm-config", "non-empty-charm-config"],
+)
+def test_environment_juju_secret_overrides_charm_config(
+    context,
+    state,
+    temporal_worker_container,
+    config,
+    encryption_key_secret,
+    vault_nonce_secret,
+    charm_encryption_key,
+    expected_temporal_key,
+    expected_twc_key,
 ):
     state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    environment_config = textwrap.dedent(
-        f"""
-        juju:
-            - secret-id: {encryption_key_secret.id}
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: encryption-key
-        """
-    )
+    environment_config = _build_environment_config(secret_id=encryption_key_secret.id)
 
-    state_out = dataclasses.replace(state_out, config={**config, "environment": environment_config})
+    state_out = dataclasses.replace(
+        state_out,
+        config={**config, "encryption-key": charm_encryption_key, "environment": environment_config},
+    )
     with unittest.mock.patch(
         "ops.jujuversion.JujuVersion.from_environ", return_value=ops.jujuversion.JujuVersion(version="3.6")
     ):
         state_out = context.run(context.on.config_changed(), state_out)
 
-    expected_env = {**WANT_ENV, "TEMPORAL_ENCRYPTION_KEY": "secret-encryption-key"}
+    expected_env = {
+        **WANT_ENV,
+        "TEMPORAL_ENCRYPTION_KEY": expected_temporal_key,
+        "TWC_ENCRYPTION_KEY": expected_twc_key,
+    }
     assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
         {
             "services": {
@@ -481,20 +530,8 @@ def test_environment_precedence_vault_over_juju_over_env(
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    environment_config = textwrap.dedent(
-        f"""
-        env:
-            - name: TEMPORAL_ENCRYPTION_KEY
-              value: env-value
-        juju:
-            - secret-id: {encryption_key_secret.id}
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: encryption-key
-        vault:
-            - path: secrets
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: token
-        """
+    environment_config = _build_environment_config(
+        secret_id=encryption_key_secret.id, include_env=True, include_vault=True
     )
 
     state_out = dataclasses.replace(state_out, config={**config, "environment": environment_config})
@@ -530,51 +567,6 @@ def test_environment_precedence_vault_over_juju_over_env(
     )
 
 
-def test_environment_juju_secret_overrides_non_empty_charm_config(
-    context, state, temporal_worker_container, config, encryption_key_secret, vault_nonce_secret
-):
-    state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
-    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
-    state_out = context.run(context.on.config_changed(), state_out)
-
-    environment_config = textwrap.dedent(
-        f"""
-        juju:
-            - secret-id: {encryption_key_secret.id}
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: encryption-key
-        """
-    )
-
-    state_out = dataclasses.replace(
-        state_out,
-        config={**config, "encryption-key": "plaintext-config-key", "environment": environment_config},
-    )
-    with unittest.mock.patch(
-        "ops.jujuversion.JujuVersion.from_environ", return_value=ops.jujuversion.JujuVersion(version="3.6")
-    ):
-        state_out = context.run(context.on.config_changed(), state_out)
-
-    expected_env = {
-        **WANT_ENV,
-        "TEMPORAL_ENCRYPTION_KEY": "secret-encryption-key",
-        "TWC_ENCRYPTION_KEY": "plaintext-config-key",
-    }
-    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
-        {
-            "services": {
-                "temporal-worker": {
-                    "summary": "temporal worker",
-                    "command": "/app/scripts/start-worker.sh",
-                    "startup": "enabled",
-                    "override": "replace",
-                    "environment": expected_env,
-                },
-            },
-        }
-    )
-
-
 def test_auth_secret_overrides_environment_auth_keys(
     context, state, temporal_worker_container, config, encryption_key_secret, oidc_auth_secret, vault_nonce_secret
 ):
@@ -582,14 +574,7 @@ def test_auth_secret_overrides_environment_auth_keys(
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    environment_config = textwrap.dedent(
-        f"""
-        juju:
-            - secret-id: {encryption_key_secret.id}
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: encryption-key
-        """
-    )
+    environment_config = _build_environment_config(secret_id=encryption_key_secret.id)
 
     state_out = dataclasses.replace(
         state_out,

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -436,6 +436,187 @@ def test_valid_environment_config(context, state, temporal_worker_container, con
         )
 
 
+def test_environment_juju_secret_overrides_empty_charm_config(
+    context, state, temporal_worker_container, config, encryption_key_secret, vault_nonce_secret
+):
+    state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    environment_config = textwrap.dedent(
+        f"""
+        juju:
+            - secret-id: {encryption_key_secret.id}
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: encryption-key
+        """
+    )
+
+    state_out = dataclasses.replace(state_out, config={**config, "environment": environment_config})
+    with unittest.mock.patch(
+        "ops.jujuversion.JujuVersion.from_environ", return_value=ops.jujuversion.JujuVersion(version="3.6")
+    ):
+        state_out = context.run(context.on.config_changed(), state_out)
+
+    expected_env = {**WANT_ENV, "TEMPORAL_ENCRYPTION_KEY": "secret-encryption-key"}
+    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
+        {
+            "services": {
+                "temporal-worker": {
+                    "summary": "temporal worker",
+                    "command": "/app/scripts/start-worker.sh",
+                    "startup": "enabled",
+                    "override": "replace",
+                    "environment": expected_env,
+                },
+            },
+        }
+    )
+
+
+def test_environment_precedence_vault_over_juju_over_env(
+    context, state, temporal_worker_container, config, encryption_key_secret, vault_nonce_secret
+):
+    state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    environment_config = textwrap.dedent(
+        f"""
+        env:
+            - name: TEMPORAL_ENCRYPTION_KEY
+              value: env-value
+        juju:
+            - secret-id: {encryption_key_secret.id}
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: encryption-key
+        vault:
+            - path: secrets
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: token
+        """
+    )
+
+    state_out = dataclasses.replace(state_out, config={**config, "environment": environment_config})
+    with unittest.mock.patch(
+        "ops.jujuversion.JujuVersion.from_environ", return_value=ops.jujuversion.JujuVersion(version="3.6")
+    ), unittest.mock.patch(
+        "relations.vault.VaultRelation.get_vault_config", return_value=VAULT_CONFIG
+    ), unittest.mock.patch(
+        "relations.vault.VaultRelation.get_vault_client"
+    ) as get_vault_client, unittest.mock.patch(
+        "os.makedirs"
+    ), unittest.mock.patch(
+        "builtins.open", new_callable=unittest.mock.mock_open
+    ):
+        mock_vault_client = unittest.mock.Mock()
+        mock_vault_client.read_secret.return_value = "vault-value"
+        get_vault_client.return_value = mock_vault_client
+        state_out = context.run(context.on.config_changed(), state_out)
+
+    expected_env = {**WANT_ENV, "TEMPORAL_ENCRYPTION_KEY": "vault-value"}
+    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
+        {
+            "services": {
+                "temporal-worker": {
+                    "summary": "temporal worker",
+                    "command": "/app/scripts/start-worker.sh",
+                    "startup": "enabled",
+                    "override": "replace",
+                    "environment": expected_env,
+                },
+            },
+        }
+    )
+
+
+def test_environment_juju_secret_overrides_non_empty_charm_config(
+    context, state, temporal_worker_container, config, encryption_key_secret, vault_nonce_secret
+):
+    state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    environment_config = textwrap.dedent(
+        f"""
+        juju:
+            - secret-id: {encryption_key_secret.id}
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: encryption-key
+        """
+    )
+
+    state_out = dataclasses.replace(
+        state_out,
+        config={**config, "encryption-key": "plaintext-config-key", "environment": environment_config},
+    )
+    with unittest.mock.patch(
+        "ops.jujuversion.JujuVersion.from_environ", return_value=ops.jujuversion.JujuVersion(version="3.6")
+    ):
+        state_out = context.run(context.on.config_changed(), state_out)
+
+    expected_env = {
+        **WANT_ENV,
+        "TEMPORAL_ENCRYPTION_KEY": "secret-encryption-key",
+        "TWC_ENCRYPTION_KEY": "plaintext-config-key",
+    }
+    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
+        {
+            "services": {
+                "temporal-worker": {
+                    "summary": "temporal worker",
+                    "command": "/app/scripts/start-worker.sh",
+                    "startup": "enabled",
+                    "override": "replace",
+                    "environment": expected_env,
+                },
+            },
+        }
+    )
+
+
+def test_auth_secret_overrides_environment_auth_keys(
+    context, state, temporal_worker_container, config, encryption_key_secret, oidc_auth_secret, vault_nonce_secret
+):
+    state = dataclasses.replace(state, secrets=[encryption_key_secret, oidc_auth_secret, vault_nonce_secret])
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    environment_config = textwrap.dedent(
+        f"""
+        juju:
+            - secret-id: {encryption_key_secret.id}
+              name: TEMPORAL_ENCRYPTION_KEY
+              key: encryption-key
+        """
+    )
+
+    state_out = dataclasses.replace(
+        state_out,
+        config={**config, "auth-secret-id": oidc_auth_secret.id, "environment": environment_config},
+    )
+    with unittest.mock.patch(
+        "ops.jujuversion.JujuVersion.from_environ", return_value=ops.jujuversion.JujuVersion(version="3.6")
+    ):
+        state_out = context.run(context.on.config_changed(), state_out)
+
+    expected_env = {**WANT_ENV}
+    expected_env.update(**WANT_ENV_AUTH)
+    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
+        {
+            "services": {
+                "temporal-worker": {
+                    "summary": "temporal worker",
+                    "command": "/app/scripts/start-worker.sh",
+                    "startup": "enabled",
+                    "override": "replace",
+                    "environment": expected_env,
+                },
+            },
+        }
+    )
+
+
 @pytest.mark.database_relation_skipped
 def test_blocked_by_missing_db_name(context, state, temporal_worker_container, config):
     config_without_db_name = {**config}

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -144,13 +144,22 @@ WANT_ENV_AUTH = {
 }
 
 
-def _build_environment_config(secret_id: str, include_env: bool = False, include_vault: bool = False) -> str:
-    """Build environment config YAML for encryption-key precedence tests."""
+def _build_environment_config(
+    secret_id: str,
+    variable_name: str = "TEMPORAL_ENCRYPTION_KEY",
+    secret_key: str = "encryption-key",
+    include_env: bool = False,
+    include_vault: bool = False,
+    env_value: str = "env-value",
+    vault_path: str = "secrets",
+    vault_key: str = "token",
+) -> str:
+    """Build environment config YAML for env/juju/vault precedence tests."""
     env_section = (
         """
         env:
-            - name: TEMPORAL_ENCRYPTION_KEY
-              value: env-value
+            - name: {variable_name}
+              value: {env_value}
         """
         if include_env
         else ""
@@ -158,23 +167,28 @@ def _build_environment_config(secret_id: str, include_env: bool = False, include
     vault_section = (
         """
         vault:
-            - path: secrets
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: token
+            - path: {vault_path}
+              name: {variable_name}
+              key: {vault_key}
         """
         if include_vault
         else ""
     )
     return textwrap.dedent(
         f"""
-        {env_section}
+        {env_section.format(variable_name=variable_name, env_value=env_value)}
         juju:
             - secret-id: {secret_id}
-              name: TEMPORAL_ENCRYPTION_KEY
-              key: encryption-key
-        {vault_section}
+              name: {variable_name}
+              key: {secret_key}
+        {vault_section.format(variable_name=variable_name, vault_path=vault_path, vault_key=vault_key)}
         """
     )
+
+
+def _get_plan_environment(state_out: ops.testing.State) -> dict:
+    """Return temporal-worker environment section from the pebble plan."""
+    return state_out.get_container("temporal-worker").plan.to_dict()["services"]["temporal-worker"]["environment"]
 
 
 @pytest.fixture
@@ -490,7 +504,6 @@ def test_environment_juju_secret_overrides_charm_config(
 ):
     state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
-    state_out = context.run(context.on.config_changed(), state_out)
 
     environment_config = _build_environment_config(secret_id=encryption_key_secret.id)
 
@@ -503,24 +516,9 @@ def test_environment_juju_secret_overrides_charm_config(
     ):
         state_out = context.run(context.on.config_changed(), state_out)
 
-    expected_env = {
-        **WANT_ENV,
-        "TEMPORAL_ENCRYPTION_KEY": expected_temporal_key,
-        "TWC_ENCRYPTION_KEY": expected_twc_key,
-    }
-    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
-        {
-            "services": {
-                "temporal-worker": {
-                    "summary": "temporal worker",
-                    "command": "/app/scripts/start-worker.sh",
-                    "startup": "enabled",
-                    "override": "replace",
-                    "environment": expected_env,
-                },
-            },
-        }
-    )
+    actual_env = _get_plan_environment(state_out)
+    assert actual_env["TEMPORAL_ENCRYPTION_KEY"] == expected_temporal_key
+    assert actual_env["TWC_ENCRYPTION_KEY"] == expected_twc_key
 
 
 def test_environment_precedence_vault_over_juju_over_env(
@@ -528,10 +526,12 @@ def test_environment_precedence_vault_over_juju_over_env(
 ):
     state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
-    state_out = context.run(context.on.config_changed(), state_out)
 
     environment_config = _build_environment_config(
-        secret_id=encryption_key_secret.id, include_env=True, include_vault=True
+        secret_id=encryption_key_secret.id,
+        variable_name="test_key",
+        include_env=True,
+        include_vault=True,
     )
 
     state_out = dataclasses.replace(state_out, config={**config, "environment": environment_config})
@@ -551,20 +551,8 @@ def test_environment_precedence_vault_over_juju_over_env(
         get_vault_client.return_value = mock_vault_client
         state_out = context.run(context.on.config_changed(), state_out)
 
-    expected_env = {**WANT_ENV, "TEMPORAL_ENCRYPTION_KEY": "vault-value"}
-    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
-        {
-            "services": {
-                "temporal-worker": {
-                    "summary": "temporal worker",
-                    "command": "/app/scripts/start-worker.sh",
-                    "startup": "enabled",
-                    "override": "replace",
-                    "environment": expected_env,
-                },
-            },
-        }
-    )
+    actual_env = _get_plan_environment(state_out)
+    assert actual_env["test_key"] == "vault-value"
 
 
 def test_auth_secret_overrides_environment_auth_keys(
@@ -572,7 +560,6 @@ def test_auth_secret_overrides_environment_auth_keys(
 ):
     state = dataclasses.replace(state, secrets=[encryption_key_secret, oidc_auth_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
-    state_out = context.run(context.on.config_changed(), state_out)
 
     environment_config = _build_environment_config(secret_id=encryption_key_secret.id)
 
@@ -585,21 +572,9 @@ def test_auth_secret_overrides_environment_auth_keys(
     ):
         state_out = context.run(context.on.config_changed(), state_out)
 
-    expected_env = {**WANT_ENV}
-    expected_env.update(**WANT_ENV_AUTH)
-    assert sorted(state_out.get_container("temporal-worker").plan.to_dict()) == sorted(
-        {
-            "services": {
-                "temporal-worker": {
-                    "summary": "temporal worker",
-                    "command": "/app/scripts/start-worker.sh",
-                    "startup": "enabled",
-                    "override": "replace",
-                    "environment": expected_env,
-                },
-            },
-        }
-    )
+    actual_env = _get_plan_environment(state_out)
+    for key, value in WANT_ENV_AUTH.items():
+        assert actual_env[key] == value
 
 
 @pytest.mark.database_relation_skipped

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -154,7 +154,10 @@ def _build_environment_config(
     vault_path: str = "secrets",
     vault_key: str = "token",
 ) -> str:
-    """Build environment config YAML for env/juju/vault precedence tests."""
+    """Build `environment` config YAML (env / juju / vault blocks) for precedence tests.
+
+    Used to avoid duplicating YAML; callers choose variable name and which sections to include.
+    """
     env_section = (
         """
         env:
@@ -187,7 +190,7 @@ def _build_environment_config(
 
 
 def _get_plan_environment(state_out: ops.testing.State) -> dict:
-    """Return temporal-worker environment section from the pebble plan."""
+    """Return the Pebble `environment` dict for the temporal-worker service (focused assertions)."""
     return state_out.get_container("temporal-worker").plan.to_dict()["services"]["temporal-worker"]["environment"]
 
 
@@ -502,6 +505,10 @@ def test_environment_juju_secret_overrides_charm_config(
     expected_temporal_key,
     expected_twc_key,
 ):
+    """Juju secret in `environment` must override charm-derived TEMPORAL_ENCRYPTION_KEY (see #36).
+
+    Charm maps encryption-key to both TWC_* and TEMPORAL_*; juju supplies TEMPORAL_ENCRYPTION_KEY only.
+    """
     state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
 
@@ -524,6 +531,10 @@ def test_environment_juju_secret_overrides_charm_config(
 def test_environment_precedence_vault_over_juju_over_env(
     context, state, temporal_worker_container, config, encryption_key_secret, vault_nonce_secret
 ):
+    """Within `environment`, merge order is vault over juju over env for the same key.
+
+    Uses a non-reserved variable name so vault env rules do not reject TEMPORAL_/TWC_ prefixes.
+    """
     state = dataclasses.replace(state, secrets=[encryption_key_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
 
@@ -558,6 +569,7 @@ def test_environment_precedence_vault_over_juju_over_env(
 def test_auth_secret_overrides_environment_auth_keys(
     context, state, temporal_worker_container, config, encryption_key_secret, oidc_auth_secret, vault_nonce_secret
 ):
+    """auth-secret-id must win over `environment` juju bindings for overlapping auth keys."""
     state = dataclasses.replace(state, secrets=[encryption_key_secret, oidc_auth_secret, vault_nonce_secret])
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Fixes config precedence so values from environment (env/juju/vault) are no longer overwritten by charm config defaults.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
## Closes #36

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
- `_update` now applies self.config-derived TWC_/TEMPORAL_ values first, then overlays `create_env()` values from the environment config.
- Added scenario tests to cover:
   env/juju/vault precedence
   Juju secret override of charm config
   auth-secret-id staying highest priority for auth keys
---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
