### PR TITLE
[WF-343] Add temporal-host-info to Terraform requires output

### DIFF
--- a/terraform/justfile
+++ b/terraform/justfile
@@ -102,4 +102,4 @@ test: (build-and-push-image)
 
     just apply "./test/test.tfvars"
 
-    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Invalid config: host value missing'))"
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && (unit.workload-message == 'Invalid config: host value missing' || unit.workload-message == 'temporal-host-info relation not established; set deprecated \`host\` config as fallback')))"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,8 +11,9 @@ output "provides" {
 
 output "requires" {
   value = {
-    logging  = "logging"
-    vault    = "vault"
-    database = "postgresql_client"
+    logging            = "logging"
+    vault              = "vault"
+    database           = "postgresql_client"
+    temporal_host_info = "temporal-host-info"
   }
 }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -275,7 +275,7 @@ async def setup_temporal_ecosystem(ops_test: OpsTest):
         ops_test.model.deploy(
             APP_NAME_SERVER, channel="1.23/edge", config={"num-history-shards": 1}, base="ubuntu@24.04"
         ),
-        ops_test.model.deploy(APP_NAME_ADMIN, channel="edge"),
+        ops_test.model.deploy(APP_NAME_ADMIN, channel="1.23/edge"),
         ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381),
     )
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -174,7 +174,7 @@ async def run_sample_workflow(ops_test: OpsTest, workflow_type=None, use_env_var
 
 
 async def register_temporal_namespace(ops_test: OpsTest, namespace: str):
-    """Register a namespace on the Temporal server via the admin charm tctl action.
+    """Register a namespace on the Temporal server via the admin charm CLI action.
 
     Args:
         ops_test: PyTest object.
@@ -183,11 +183,11 @@ async def register_temporal_namespace(ops_test: OpsTest, namespace: str):
     action = (
         await ops_test.model.applications[APP_NAME_ADMIN]
         .units[0]
-        .run_action("tctl", args=f"--ns {namespace} namespace register -rd 3")
+        .run_action("cli", args=f"operator namespace create --namespace {namespace} --retention 3d")
     )
     result = (await action.wait()).results
-    logger.info("tctl namespace %s: %s", namespace, result)
-    assert "result" in result and result["result"] == "command succeeded"
+    logger.info("cli namespace %s: %s", namespace, result)
+    assert result.get("return-code") == 0
 
 
 async def get_application_url(ops_test: OpsTest, application, port):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -233,6 +233,7 @@ async def perform_temporal_integrations(ops_test: OpsTest):
     await ops_test.model.integrate(f"{APP_NAME_SERVER}:db", "postgresql-k8s:database")
     await ops_test.model.integrate(f"{APP_NAME_SERVER}:visibility", "postgresql-k8s:database")
     await ops_test.model.integrate(f"{APP_NAME_SERVER}:admin", f"{APP_NAME_ADMIN}:admin")
+    await ops_test.model.integrate(f"{APP_NAME_SERVER}:temporal-host-info", f"{APP_NAME_ADMIN}:temporal-host-info")
     await ops_test.model.wait_for_idle(apps=[APP_NAME_SERVER], status="active", raise_on_blocked=False, timeout=180)
     await ops_test.model.wait_for_idle(apps=[APP_NAME_SERVER], status="active", raise_on_blocked=False, timeout=180)
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Expose `temporal_host_info = "temporal-host-info"` in `output "requires"` in `terraform/outputs.tf` for consistency with other Temporal operators and for any Terraform that composes the worker module and integrates `temporal-host-info`.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
