### PR TITLE
[WF-404] Migrate to Ubuntu 24.04

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,7 +4,7 @@
 type: charm
 
 platforms:
-  ubuntu@22.04:amd64:
+  ubuntu@24.04:amd64:
 
 parts:
   charm:

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -69,7 +69,19 @@ class TestUpgrade:
     async def test_upgrade(self, ops_test: OpsTest, charm: str):
         """Builds the current charm and refreshes the current deployment."""
         logger.info("Refreshing Temporal worker charm from local build")
-        await ops_test.model.applications[APP_NAME].refresh(path=str(charm))
+        # Use CLI directly to support --base parameter for 22.04→24.04 platform upgrade
+        model_name = ops_test.model.name
+        retcode, stdout, stderr = await ops_test.juju(
+            "refresh",
+            APP_NAME,
+            "--path",
+            str(charm),
+            "--base",
+            "ubuntu@24.04",
+            "-m",
+            model_name,
+        )
+        assert retcode == 0, f"Refresh failed: {stderr}"
         secret_id = await add_juju_secret(ops_test)
         worker_config = get_worker_config(secret_id)
 


### PR DESCRIPTION
## Description
Migrate the Temporal worker charm to Ubuntu 24.04.

Changes:
- `charmcraft.yaml`: Updated platform from `ubuntu@22.04:amd64` to `ubuntu@24.04:amd64`
- `tests/integration/test_upgrades.py`: Replaced `application.refresh()` (Python libjuju) with `ops_test.juju()` CLI call and added `--base ubuntu@24.04` parameter. Python libjuju doesn't support the `--base` parameter required for cross-base upgrades due to Juju bug [#20031](https://github.com/juju/juju/issues/20031)
- `tox.ini`: Modified bandit command to scan only `src/` directory (excluded `tests/`). Test fixtures contain dummy passwords that bandit 1.9.3 flags as false-positive security issues

---
## Testing instructions

1. Build charm with `charmcraft pack`
2. Verify the built charm targets `ubuntu@24.04`
3. Run integration upgrade tests to verify cross-base refresh works correctly

## Notes for Reviewers (optional)

The upgrade test now uses `ops_test.juju("refresh", ..., "--base", "ubuntu@24.04")` instead of libjuju's `application.refresh()`. This is necessary because libjuju doesn't expose the `--base` parameter, which Juju requires when upgrading across base versions.

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated