### PR TITLE
fix: remove cancel-in-fail from integration tests workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,8 +1,5 @@
 name: Integration tests
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 on:
   pull_request:
   workflow_call:


### PR DESCRIPTION


## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

When a workflow is called via workflow_call, the concurrency should be controlled by the parent workflow, not the child. This commit removes the concurrency field from the integration tests workflow to prevent issues when reused by another workflow.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

N/A

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->


This commit resolves the issues observed [here](https://github.com/canonical/temporal-worker-k8s-operator/actions/runs/25166155149/job/73841609682).

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
