### PR TITLE
fix: prevent CI concurrency deadlock with terraform reusable workflow

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,7 +1,7 @@
 name: Terraform checks
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: terraform-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION

## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

When invoked via workflow_call, github.workflow resolves to the caller's name ("CI"), so terraform.yaml's concurrency group evaluated to the same value as the parent workflow's group, causing GitHub to cancel the run with a deadlock between the top-level workflow and test-terraform-module.

Use a constant prefix for terraform.yaml's concurrency group so it stays distinct from the caller's group.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

N/A

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

Fixes this issue:

```
  CI                                                                                                    
  Canceling since a deadlock was detected for concurrency group: 'CI-refs/heads/track/1.0' between a    
  top level workflow and 'test-terraform-module' 
```

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
