### PR TITLE
Set release channel to 2.0/edge for track/2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     secrets: inherit
     with:
-      release-channel: "1.0/edge"
+      release-channel: "2.0/edge"
       charm-path: "."
       charmcraft-channel: "3.x/candidate"
       runners: '["ubuntu-latest"]'


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Updates the release-channel input in ci.yaml from 1.0/edge to 2.0/edge so merges to track/2.0 publish to the newly-created 2.0 track on Charmhub.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
