### PR TITLE
fix: pin kubernetes<36 to avoid v36.0.0 auth regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ unit = [
 integration = [
     "ipdb==0.13.9",
     "juju==3.5.2.1",
+    # Pin <36 to avoid v36.0.0 auth regression (https://github.com/kubernetes-client/python/issues/25844).
+    # Remove upper bound once a patched release is available.
     "kubernetes>=33.0.0,<36",
     "pytest==7.1.3",
     "pytest-operator==0.31.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ unit = [
 integration = [
     "ipdb==0.13.9",
     "juju==3.5.2.1",
+    "kubernetes>=33.0.0,<36",
     "pytest==7.1.3",
     "pytest-operator==0.31.1",
     "temporal-lib-py==1.4.3",


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
kubernetes v36.0.0 introduced a regression where load_incluster_config() silently drops the Authorization header, causing all in-cluster API calls to fail with 401. See kubernetes-client/python#2584.

Pin kubernetes<36 to prevent pip from resolving to the broken version at install time. Remove the upper bound once a patched release is available.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
