### PR TITLE
fix: detect Temporal SDK workflow eviction loop in update-status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -195,6 +195,19 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             self._update(event)
             return
 
+        try:
+            service = container.get_service(self.name)
+            if not service.is_running():
+                logger.error(
+                    "temporal-worker service is not running; it may be caught in a crash/restart loop - check logs for details"
+                )
+                self.unit.status = BlockedStatus(
+                    "temporal-worker service is not running; check logs for crash details"
+                )
+                return
+        except pebble.APIError as e:
+            logger.warning(f"Could not retrieve service status: {e}")
+
         self.unit.status = ActiveStatus(
             f"worker listening to namespace {self.config['namespace']!r} on queue {self.config['queue']!r}"
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -208,6 +208,17 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         except pebble.APIError as e:
             logger.warning(f"Could not retrieve service status: {e}")
 
+        if self._has_eviction_loop_error(container):
+            logger.error(
+                "Temporal SDK workflow eviction loop detected in pebble logs: "
+                "the worker has stuck slots and may not complete workflow tasks. "
+                "Restart the worker to recover (juju run temporal-worker-k8s/<unit> restart)."
+            )
+            self.unit.status = BlockedStatus(
+                "temporal-worker: workflow eviction loop detected - restart required"
+            )
+            return
+
         self.unit.status = ActiveStatus(
             f"worker listening to namespace {self.config['namespace']!r} on queue {self.config['queue']!r}"
         )
@@ -225,6 +236,39 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             plan = container.get_plan().to_dict()
             return bool(plan and plan["services"].get(self.name, {}))
         except pebble.ConnectionError:
+            return False
+
+    def _has_eviction_loop_error(self, container) -> bool:
+        """Scan recent pebble service logs for the Temporal SDK workflow eviction loop error.
+
+        When a workflow task deadlocks (e.g. due to a blocking call inside the workflow
+        coroutine) the Temporal SDK fails to cleanly evict the cached workflow state and
+        logs the following at ERROR level:
+
+          "Failed running eviction job for run ID <X>, continually retrying eviction.
+           Since eviction could not be processed, this worker may not complete and the
+           slot may remain forever used unless it eventually completes."
+
+        The service continues running (pebble status stays ACTIVE), so this condition
+        is invisible to a simple service-status check.  This method reads the last 200
+        log lines from the pebble log API and checks for the sentinel phrase.
+
+        Args:
+            container: application container
+
+        Returns:
+            True if the eviction loop error was found in recent service logs.
+        """
+        try:
+            response = container._pebble._request_raw(
+                "GET",
+                "/v1/logs",
+                query={"services": self.name, "n": "200"},
+            )
+            log_data = response.read().decode("utf-8", errors="replace")
+            return "continually retrying eviction" in log_data
+        except Exception as e:
+            logger.debug(f"Could not scan pebble logs for eviction error: {e}")
             return False
 
     def get_auth_config_from_juju_secret(self) -> dict:

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -275,6 +275,24 @@ def test_ready(context, state, temporal_worker_container, namespace, queue):
     assert state_out.unit_status == ops.ActiveStatus(f"worker listening to namespace {namespace!r} on queue {queue!r}")
 
 
+def test_service_crash_restart_loop_detected(context, state, temporal_worker_container, namespace, queue):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    # Simulate the service having crashed (pebble in backoff between restarts)
+    crashed_container = dataclasses.replace(
+        state_out.get_container("temporal-worker"),
+        service_statuses={"temporal-worker": ops.pebble.ServiceStatus.INACTIVE},
+    )
+    state_out = dataclasses.replace(state_out, containers=[crashed_container])
+
+    state_out = context.run(context.on.update_status(), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        "temporal-worker service is not running; check logs for crash details"
+    )
+
+
 def test_invalid_juju_secret(
     context, state, temporal_worker_container, config, missing_oidc_auth_type_secret, vault_nonce_secret
 ):

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -10,6 +10,8 @@ import ops
 import ops.testing
 import pytest
 
+from charm import TemporalWorkerK8SOperatorCharm
+
 logger = logging.getLogger(__name__)
 
 CONFIG = {
@@ -290,6 +292,40 @@ def test_service_crash_restart_loop_detected(context, state, temporal_worker_con
 
     assert state_out.unit_status == ops.BlockedStatus(
         "temporal-worker service is not running; check logs for crash details"
+    )
+
+
+def test_eviction_loop_detected_in_pebble_logs(context, state, temporal_worker_container):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    # Service is ACTIVE (the worker keeps running despite the eviction error),
+    # but pebble logs contain the Temporal SDK eviction sentinel.
+    with unittest.mock.patch.object(
+        TemporalWorkerK8SOperatorCharm,
+        "_has_eviction_loop_error",
+        return_value=True,
+    ):
+        state_out = context.run(context.on.update_status(), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        "temporal-worker: workflow eviction loop detected - restart required"
+    )
+
+
+def test_no_eviction_loop_sets_active(context, state, temporal_worker_container, namespace, queue):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    with unittest.mock.patch.object(
+        TemporalWorkerK8SOperatorCharm,
+        "_has_eviction_loop_error",
+        return_value=False,
+    ):
+        state_out = context.run(context.on.update_status(), state_out)
+
+    assert state_out.unit_status == ops.ActiveStatus(
+        f"worker listening to namespace {namespace!r} on queue {queue!r}"
     )
 
 


### PR DESCRIPTION
## Description

Depends on #105 (must merge first). Once #105 merges, this PR will show only the eviction-loop changes.

When the Temporal Python SDK fails to evict a cached workflow instance (because a blocking call inside the workflow coroutine caused a _DeadlockError and left a pending asyncio task), it logs at ERROR level:

> Failed running eviction job for run ID <X>, continually retrying eviction.
> Since eviction could not be processed, this worker may not complete and the
>  slot may remain forever used unless it eventually completes.

The worker process continues running (Pebble service status: ACTIVE), so the existing service-running check does not catch this condition. The Juju unit falsely reports active/idle while the affected slot is permanently occupied and the stuck workflow tasks cycle between `WORKFLOW_TASK_FAILED` and `WORKFLOW_TASK_TIMED_OUT` indefinitely.

While the root cause of the eviction loop lies within the code and a fix is required, the charm could detect such situations and give an immediate hint to the user checking on `juju status`.

This adds `_has_eviction_loop_error(container)` which uses the Pebble raw log API (`GET /v1/logs?services=temporal-worker&n=200`) to scan the last 200 log lines for the sentinel phrase `continually retrying eviction`. Called in `_on_update_status` after the service-running check; sets `BlockedStatus` so the operator sees an actionable message in juju status:

  `temporal-worker: workflow eviction loop detected - restart required`

Recovery after redeploying the fix: the worker pod restarts, clearing all in-memory cache slots. Temporal's sticky task queue timeout expires and routes stuck workflow tasks to the fresh worker, which replays cleanly.

No manual Temporal UI intervention is required in the common case.

Also adds:
- test_eviction_loop_detected_in_pebble_logs scenario test
- test_no_eviction_loop_sets_active scenario test

This fixes #106. Of course, feel free to suggest a different resolution path!

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated