### PR TITLE
ci(terraform apply): use retry and use registry v2 instead of 2.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,8 @@ on:
 
 jobs:
   unit-tests:
+    permissions:
+      contents: read
+      issues: write
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,5 +8,6 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -11,7 +11,20 @@ stop-local-registry:
 
 [private]
 start-local-registry: (stop-local-registry)
-    docker run -d --network host --name registry registry:2
+    #!/usr/bin/bash
+    set -euxo pipefail
+    for attempt in {1..5}; do
+        if docker run -d -p 5000:5000 --name registry registry:2; then
+            break
+        fi
+        if [ "${attempt}" -eq 5 ]; then
+            echo "Failed to start local registry after ${attempt} attempts"
+            exit 1
+        fi
+        docker rm -f registry 2>/dev/null || true
+        echo "Failed to start registry (attempt ${attempt}); retrying in 5s..."
+        sleep 5
+    done
 
 [private]
 build-and-push-image: (start-local-registry)

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -11,7 +11,7 @@ stop-local-registry:
 
 [private]
 start-local-registry: (stop-local-registry)
-    docker run -d -p 5000:5000 --name registry registry:2.7
+    docker run -d -p 5000:5000 --name registry registry:2
 
 [private]
 build-and-push-image: (start-local-registry)

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -11,7 +11,7 @@ stop-local-registry:
 
 [private]
 start-local-registry: (stop-local-registry)
-    docker run -d -p 5000:5000 --name registry registry:2
+    docker run -d --network host --name registry registry:2
 
 [private]
 build-and-push-image: (start-local-registry)


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

In an attempt to fix a CI issue, where the container that's used as a registry in the Terraform tests exits potentially due to the container not starting successfully. This commit proposes two changes:

* Replace tag of `registry` to use 2 instead of 2.7. The 2.7 tag is a tad old and may be contributing to the issue.
* Use a retry to allow time to the container to spin up correctly before attempting any other operation on it. This change works because there seems to be a race condition between the time when the docker snap is installed and the first operation we execute on the container. Docker snap is installed and started, then `just test` fires 200ms later, the daemon socket is up (so `docker stop/rm` respond, just slowly), but Docker's internal containerd isn't ready yet.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

This is attempting to fix the issue in the CI of PR #105. Please also NOTE that the workflow file had to be changed in order for the libcheck action to apply labels to PRs. I have included the change as part of this PR, but feel free to suggest moving it to a different one.

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
