### PR TITLE
feat(charm): add pebble check for eviction loops

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -54,7 +54,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         """
         super().__init__(*args)
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
-        self.name = "temporal-worker"
+        self._service_name = "temporal-worker"
 
         self.database = DatabaseRequires(
             self, relation_name="database", database_name=self.model.config.get("db-name", None)
@@ -140,13 +140,13 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         Args:
             event:The event triggered by the restart action
         """
-        container = self.unit.get_container(self.name)
+        container = self.unit.get_container(self._service_name)
         if not container.can_connect():
             event.fail("Failed to connect to the container")
             return
 
         self.unit.status = MaintenanceStatus("restarting worker")
-        container.restart(self.name)
+        container.restart(self._service_name)
 
         event.set_results({"result": "worker successfully restarted"})
 
@@ -191,7 +191,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             self.unit.status = BlockedStatus(str(err))
             return
 
-        container = self.unit.get_container(self.name)
+        container = self.unit.get_container(self._service_name)
         valid_pebble_plan = self._validate_pebble_plan(container)
         if not valid_pebble_plan:
             self._update(event)
@@ -205,7 +205,17 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         Args:
             event: The event triggered when the pebble check fails.
         """
-        self.unit.status = BlockedStatus("temporal-worker service is not running; check logs for crash details")
+        if event.info.name == "eviction-loop-check":
+            logger.error(
+                "Temporal SDK workflow eviction loop detected: the worker has stuck slots "
+                "and may not complete workflow tasks. "
+                "Fix the workflow code before restarting the worker."
+            )
+            self.unit.status = BlockedStatus(
+                "eviction loop detected - fix workflow code before restarting"
+            )
+        else:
+            self.unit.status = BlockedStatus("temporal-worker service is not running; check logs for crash details")
 
     @log_event_handler(logger)
     def _on_pebble_check_recovered(self, event):
@@ -229,7 +239,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         """
         try:
             plan = container.get_plan().to_dict()
-            return bool(plan and plan["services"].get(self.name, {}))
+            return bool(plan and plan["services"].get(self._service_name, {}))
         except pebble.ConnectionError:
             return False
 
@@ -351,7 +361,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         Args:
             event: The event triggered when the relation changed.
         """
-        container = self.unit.get_container(self.name)
+        container = self.unit.get_container(self._service_name)
         if not container.can_connect():
             event.defer()
             self.unit.status = WaitingStatus("waiting for pebble api")
@@ -458,7 +468,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         pebble_layer = {
             "summary": "temporal worker layer",
             "services": {
-                self.name: {
+                self._service_name: {
                     "summary": "temporal worker",
                     "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
@@ -471,11 +481,20 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
                     "override": "replace",
                     "threshold": 3,
                     "exec": {"command": "pgrep -f start-worker.sh"},
-                }
+                },
+                # NOTE: this eviction log only works for the Go and Python SDKs specifically
+                "eviction-loop-check": {
+                    "override": "replace",
+                    "period": "5m",
+                    "threshold": 1,
+                    "exec": {
+                        "command": f"bash -c '! pebble logs -n 50 {self._service_name} 2>/dev/null | grep -q \"continually retrying eviction\"'"
+                    },
+                },
             },
         }
 
-        container.add_layer(self.name, pebble_layer, combine=True)
+        container.add_layer(self._service_name, pebble_layer, combine=True)
 
         try:
             container.replan()

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -682,7 +682,7 @@ def test_eviction_loop_check_detected(context, state, temporal_worker_container)
         state_out = context.run(context.on.pebble_check_failed(container, check_info), state_out)
 
     assert state_out.unit_status == ops.BlockedStatus(
-        "temporal-worker: eviction loop detected - fix workflow code before restarting"
+        "eviction loop detected - fix workflow code before restarting"
     )
 
 

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -622,18 +622,18 @@ def test_blocked_by_missing_db_name(context, state, temporal_worker_container, c
     assert state_out.unit_status == ops.BlockedStatus("Invalid config: db name value missing")
 
 
-def _make_check_state(state_out):
-    """Return (container, check_info, updated_state) with the pebble check registered.
+def _make_check_state(state_out, name, threshold):
+    """Return (container, check_info, updated_state) with the named check registered.
 
     See https://github.com/canonical/operator/issues/2565: the consistency checker builds
     all_checks using raw container names but compares against the normalised event name,
     so containers with hyphens always fail. Patching here until the bug is fixed.
     """
     check_info = ops.testing.CheckInfo(
-        name="start-worker-check",
+        name=name,
         level=ops.pebble.CheckLevel.UNSET,
         startup=ops.pebble.CheckStartup.UNSET,
-        threshold=3,
+        threshold=threshold,
     )
     container = dataclasses.replace(
         state_out.get_container("temporal-worker"),
@@ -646,7 +646,7 @@ def test_pebble_check_failed(context, state, temporal_worker_container):
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    container, check_info, state_out = _make_check_state(state_out)
+    container, check_info, state_out = _make_check_state(state_out, "start-worker-check", threshold=3)
 
     # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
     with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
@@ -659,7 +659,7 @@ def test_pebble_check_recovered(context, state, temporal_worker_container, names
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    container, check_info, state_out = _make_check_state(state_out)
+    container, check_info, state_out = _make_check_state(state_out, "start-worker-check", threshold=3)
 
     # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
     with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
@@ -669,6 +669,21 @@ def test_pebble_check_recovered(context, state, temporal_worker_container, names
     with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
         state_out = context.run(context.on.pebble_check_recovered(container, check_info), state_out)
     assert state_out.unit_status == ops.ActiveStatus(f"worker listening to namespace {namespace!r} on queue {queue!r}")
+
+
+def test_eviction_loop_check_detected(context, state, temporal_worker_container):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    container, check_info, state_out = _make_check_state(state_out, "eviction-loop-check", threshold=1)
+
+    # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
+    with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
+        state_out = context.run(context.on.pebble_check_failed(container, check_info), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        "temporal-worker: eviction loop detected - fix workflow code before restarting"
+    )
 
 
 def test_db_relation(context, state, temporal_worker_container):


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Adds eviction-loop-check pebble check and blocks the unit whenever it fires
since the fix for an eviction loop is in the workflow code.
This commit also adds tests for the new functionality.

Fixes #106

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

1. Build and deploy the Charmed Temporal solution and this worker charm
2. Include a workflow that causes an eviction loop, in Python for instance:

```
  import asyncio
  from temporalio import workflow

  @workflow.defn
  class EvictionLoopWorkflow:
      @workflow.run
      async def run(self) -> None:
          while True:
              try:
                  await workflow.sleep(3600)
              except BaseException:
                  # Swallows asyncio.CancelledError, which the SDK uses internally
                  # to evict the workflow from the worker cache. The SDK retries the
                  # eviction indefinitely, logging "continually retrying eviction".
                  pass
```
3. Wait for the worker charm to be blocked with the message "eviction loop detected - fix workflow code before restarting" 

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

There was a suggestion from @shayancanonical to use the DB to query the logs instead of Pebble logs, after consideration, I decided to move forward with pebble logs since:

1. The eviction loop is purely a worker-side, in-memory condition
2. The Temporal server DB is not the worker's DB
3. The log is the earliest and most precise signal - as soon as the SDK sends the signal, we'll catch it

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
