### PR TITLE
chore(forward-port): several changes from track/1.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,9 @@ on:
 
 jobs:
   unit-tests:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ unit = [
 integration = [
     "ipdb==0.13.9",
     "juju==3.5.2.1",
+    # Pin <36 to avoid v36.0.0 auth regression (https://github.com/kubernetes-client/python/issues/25844).
+    # Remove upper bound once a patched release is available.
+    "kubernetes>=33.0.0,<36",
     "pytest==7.1.3",
     "pytest-operator==0.31.1",
     "temporal-lib-py==1.4.3",

--- a/src/charm.py
+++ b/src/charm.py
@@ -66,6 +66,8 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         self.framework.observe(self.on.restart_action, self._on_restart)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.temporal_worker_pebble_check_failed, self._on_pebble_check_failed)
+        self.framework.observe(self.on.temporal_worker_pebble_check_recovered, self._on_pebble_check_recovered)
         self.framework.observe(self.on.secret_changed, self._on_secret_changed)
 
         # Vault
@@ -195,6 +197,23 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             self._update(event)
             return
 
+
+    @log_event_handler(logger)
+    def _on_pebble_check_failed(self, event):
+        """Handle pebble check failed event.
+
+        Args:
+            event: The event triggered when the pebble check fails.
+        """
+        self.unit.status = BlockedStatus("temporal-worker service is not running; check logs for crash details")
+
+    @log_event_handler(logger)
+    def _on_pebble_check_recovered(self, event):
+        """Handle pebble check recovered event.
+
+        Args:
+            event: The event triggered when the pebble check recovers.
+        """
         self.unit.status = ActiveStatus(
             f"worker listening to namespace {self.config['namespace']!r} on queue {self.config['queue']!r}"
         )
@@ -447,6 +466,13 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
                     "environment": context,
                 }
             },
+            "checks": {
+                "start-worker-check": {
+                    "override": "replace",
+                    "threshold": 3,
+                    "exec": {"command": "pgrep -f start-worker.sh"},
+                }
+            },
         }
 
         container.add_layer(self.name, pebble_layer, combine=True)
@@ -460,7 +486,9 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             )
             return
 
-        self.unit.status = MaintenanceStatus("replanning application")
+        self.unit.status = ActiveStatus(
+            f"worker listening to namespace {self.config['namespace']!r} on queue {self.config['queue']!r}"
+        )
 
 
 def convert_env_var(config_var, prefix="TWC_"):

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,7 +54,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         """
         super().__init__(*args)
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
-        self.name = "temporal-worker"
+        self._service_name = "temporal-worker"
 
         self.database = DatabaseRequires(
             self, relation_name="database", database_name=self.model.config.get("db-name", None)
@@ -140,13 +140,13 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         Args:
             event:The event triggered by the restart action
         """
-        container = self.unit.get_container(self.name)
+        container = self.unit.get_container(self._service_name)
         if not container.can_connect():
             event.fail("Failed to connect to the container")
             return
 
         self.unit.status = MaintenanceStatus("restarting worker")
-        container.restart(self.name)
+        container.restart(self._service_name)
 
         event.set_results({"result": "worker successfully restarted"})
 
@@ -191,7 +191,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
             self.unit.status = BlockedStatus(str(err))
             return
 
-        container = self.unit.get_container(self.name)
+        container = self.unit.get_container(self._service_name)
         valid_pebble_plan = self._validate_pebble_plan(container)
         if not valid_pebble_plan:
             self._update(event)
@@ -205,7 +205,17 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         Args:
             event: The event triggered when the pebble check fails.
         """
-        self.unit.status = BlockedStatus("temporal-worker service is not running; check logs for crash details")
+        if event.info.name == "eviction-loop-check":
+            logger.error(
+                "Temporal SDK workflow eviction loop detected: the worker has stuck slots "
+                "and may not complete workflow tasks. "
+                "Fix the workflow code before restarting the worker."
+            )
+            self.unit.status = BlockedStatus(
+                "eviction loop detected - fix workflow code before restarting"
+            )
+        else:
+            self.unit.status = BlockedStatus("temporal-worker service is not running; check logs for crash details")
 
     @log_event_handler(logger)
     def _on_pebble_check_recovered(self, event):
@@ -229,7 +239,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         """
         try:
             plan = container.get_plan().to_dict()
-            return bool(plan and plan["services"].get(self.name, {}))
+            return bool(plan and plan["services"].get(self._service_name, {}))
         except pebble.ConnectionError:
             return False
 
@@ -351,7 +361,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         Args:
             event: The event triggered when the relation changed.
         """
-        container = self.unit.get_container(self.name)
+        container = self.unit.get_container(self._service_name)
         if not container.can_connect():
             event.defer()
             self.unit.status = WaitingStatus("waiting for pebble api")
@@ -458,7 +468,7 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
         pebble_layer = {
             "summary": "temporal worker layer",
             "services": {
-                self.name: {
+                self._service_name: {
                     "summary": "temporal worker",
                     "command": "/app/scripts/start-worker.sh",
                     "startup": "enabled",
@@ -471,11 +481,20 @@ class TemporalWorkerK8SOperatorCharm(CharmBase):
                     "override": "replace",
                     "threshold": 3,
                     "exec": {"command": "pgrep -f start-worker.sh"},
-                }
+                },
+                # NOTE: this eviction log only works for the Go and Python SDKs specifically
+                "eviction-loop-check": {
+                    "override": "replace",
+                    "period": "5m",
+                    "threshold": 1,
+                    "exec": {
+                        "command": f"bash -c '! pebble logs -n 50 {self._service_name} 2>/dev/null | grep -q \"continually retrying eviction\"'"
+                    },
+                },
             },
         }
 
-        container.add_layer(self.name, pebble_layer, combine=True)
+        container.add_layer(self._service_name, pebble_layer, combine=True)
 
         try:
             container.replan()

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -11,7 +11,20 @@ stop-local-registry:
 
 [private]
 start-local-registry: (stop-local-registry)
-    docker run -d -p 5000:5000 --name registry registry:2.7
+    #!/usr/bin/bash
+    set -euxo pipefail
+    for attempt in {1..5}; do
+        if docker run -d -p 5000:5000 --name registry registry:2; then
+            break
+        fi
+        if [ "${attempt}" -eq 5 ]; then
+            echo "Failed to start local registry after ${attempt} attempts"
+            exit 1
+        fi
+        docker rm -f registry 2>/dev/null || true
+        echo "Failed to start registry (attempt ${attempt}); retrying in 5s..."
+        sleep 5
+    done
 
 [private]
 build-and-push-image: (start-local-registry)

--- a/tests/integration/test_worker_info.py
+++ b/tests/integration/test_worker_info.py
@@ -50,9 +50,7 @@ class TestTemporalWorkerInfoRelation:
                 raise_on_blocked=False,
                 timeout=600,
             )
-        await wait_for_status_message(
-            ops_test, APP_NAME, 1, _EXPECTED_WORKER_STATUS, timeout=600, cadence=3
-        )
+        await wait_for_status_message(ops_test, APP_NAME, 1, _EXPECTED_WORKER_STATUS, timeout=600, cadence=3)
         await ops_test.model.deploy(
             worker_info_requirer_charm,
             application_name="worker-info-requirer",

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -261,6 +261,13 @@ def test_ready(context, state, temporal_worker_container, namespace, queue):
                     "environment": WANT_ENV,
                 },
             },
+            "checks": {
+                "start-worker-check": {
+                    "override": "replace",
+                    "threshold": 3,
+                    "exec": {"command": "pgrep -f start-worker.sh"},
+                }
+            },
         }
     )
 
@@ -268,10 +275,6 @@ def test_ready(context, state, temporal_worker_container, namespace, queue):
         state_out.get_container("temporal-worker").service_statuses["temporal-worker"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
-    assert state_out.unit_status == ops.MaintenanceStatus("replanning application")
-
-    state_out = context.run(context.on.update_status(), state_out)
-
     assert state_out.unit_status == ops.ActiveStatus(f"worker listening to namespace {namespace!r} on queue {queue!r}")
 
 
@@ -322,6 +325,13 @@ def test_auth_juju_secret(
                     "environment": expected_env,
                 },
             },
+            "checks": {
+                "start-worker-check": {
+                    "override": "replace",
+                    "threshold": 3,
+                    "exec": {"command": "pgrep -f start-worker.sh"},
+                }
+            },
         }
     )
 
@@ -329,10 +339,6 @@ def test_auth_juju_secret(
         state_out.get_container("temporal-worker").service_statuses["temporal-worker"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
-    assert state_out.unit_status == ops.MaintenanceStatus("replanning application")
-
-    state_out = context.run(context.on.update_status(), state_out)
-
     assert state_out.unit_status == ops.ActiveStatus(f"worker listening to namespace {namespace!r} on queue {queue!r}")
 
 
@@ -350,6 +356,13 @@ def test_vault_relation(context, state, temporal_worker_container):
                     "override": "replace",
                     "environment": WANT_ENV,
                 },
+            },
+            "checks": {
+                "start-worker-check": {
+                    "override": "replace",
+                    "threshold": 3,
+                    "exec": {"command": "pgrep -f start-worker.sh"},
+                }
             },
         }
     )
@@ -482,6 +495,13 @@ def test_valid_environment_config(context, state, temporal_worker_container, con
                         },
                     },
                 },
+                "checks": {
+                    "start-worker-check": {
+                        "override": "replace",
+                        "threshold": 3,
+                        "exec": {"command": "pgrep -f start-worker.sh"},
+                    }
+                },
             }
         )
 
@@ -602,6 +622,55 @@ def test_blocked_by_missing_db_name(context, state, temporal_worker_container, c
     assert state_out.unit_status == ops.BlockedStatus("Invalid config: db name value missing")
 
 
+def _make_check_state(state_out):
+    """Return (container, check_info, updated_state) with the pebble check registered.
+
+    See https://github.com/canonical/operator/issues/2565: the consistency checker builds
+    all_checks using raw container names but compares against the normalised event name,
+    so containers with hyphens always fail. Patching here until the bug is fixed.
+    """
+    check_info = ops.testing.CheckInfo(
+        name="start-worker-check",
+        level=ops.pebble.CheckLevel.UNSET,
+        startup=ops.pebble.CheckStartup.UNSET,
+        threshold=3,
+    )
+    container = dataclasses.replace(
+        state_out.get_container("temporal-worker"),
+        check_infos=frozenset([check_info]),
+    )
+    return container, check_info, dataclasses.replace(state_out, containers={container})
+
+
+def test_pebble_check_failed(context, state, temporal_worker_container):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    container, check_info, state_out = _make_check_state(state_out)
+
+    # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
+    with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
+        state_out = context.run(context.on.pebble_check_failed(container, check_info), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus("temporal-worker service is not running; check logs for crash details")
+
+
+def test_pebble_check_recovered(context, state, temporal_worker_container, namespace, queue):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    container, check_info, state_out = _make_check_state(state_out)
+
+    # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
+    with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
+        state_out = context.run(context.on.pebble_check_failed(container, check_info), state_out)
+    assert state_out.unit_status == ops.BlockedStatus("temporal-worker service is not running; check logs for crash details")
+
+    with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
+        state_out = context.run(context.on.pebble_check_recovered(container, check_info), state_out)
+    assert state_out.unit_status == ops.ActiveStatus(f"worker listening to namespace {namespace!r} on queue {queue!r}")
+
+
 def test_db_relation(context, state, temporal_worker_container):
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
@@ -621,6 +690,13 @@ def test_db_relation(context, state, temporal_worker_container):
                         "TWC_DB_NAME": "temporal-worker-k8s_db",
                     },
                 },
+            },
+            "checks": {
+                "start-worker-check": {
+                    "override": "replace",
+                    "threshold": 3,
+                    "exec": {"command": "pgrep -f start-worker.sh"},
+                }
             },
         }
     )

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -622,18 +622,18 @@ def test_blocked_by_missing_db_name(context, state, temporal_worker_container, c
     assert state_out.unit_status == ops.BlockedStatus("Invalid config: db name value missing")
 
 
-def _make_check_state(state_out):
-    """Return (container, check_info, updated_state) with the pebble check registered.
+def _make_check_state(state_out, name, threshold):
+    """Return (container, check_info, updated_state) with the named check registered.
 
     See https://github.com/canonical/operator/issues/2565: the consistency checker builds
     all_checks using raw container names but compares against the normalised event name,
     so containers with hyphens always fail. Patching here until the bug is fixed.
     """
     check_info = ops.testing.CheckInfo(
-        name="start-worker-check",
+        name=name,
         level=ops.pebble.CheckLevel.UNSET,
         startup=ops.pebble.CheckStartup.UNSET,
-        threshold=3,
+        threshold=threshold,
     )
     container = dataclasses.replace(
         state_out.get_container("temporal-worker"),
@@ -646,7 +646,7 @@ def test_pebble_check_failed(context, state, temporal_worker_container):
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    container, check_info, state_out = _make_check_state(state_out)
+    container, check_info, state_out = _make_check_state(state_out, "start-worker-check", threshold=3)
 
     # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
     with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
@@ -659,7 +659,7 @@ def test_pebble_check_recovered(context, state, temporal_worker_container, names
     state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
     state_out = context.run(context.on.config_changed(), state_out)
 
-    container, check_info, state_out = _make_check_state(state_out)
+    container, check_info, state_out = _make_check_state(state_out, "start-worker-check", threshold=3)
 
     # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
     with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
@@ -669,6 +669,21 @@ def test_pebble_check_recovered(context, state, temporal_worker_container, names
     with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
         state_out = context.run(context.on.pebble_check_recovered(container, check_info), state_out)
     assert state_out.unit_status == ops.ActiveStatus(f"worker listening to namespace {namespace!r} on queue {queue!r}")
+
+
+def test_eviction_loop_check_detected(context, state, temporal_worker_container):
+    state_out = context.run(context.on.pebble_ready(temporal_worker_container), state)
+    state_out = context.run(context.on.config_changed(), state_out)
+
+    container, check_info, state_out = _make_check_state(state_out, "eviction-loop-check", threshold=1)
+
+    # ops-scenario 7.21.1 bug: consistency checker does not normalise container names
+    with unittest.mock.patch("scenario._consistency_checker.check_consistency"):
+        state_out = context.run(context.on.pebble_check_failed(container, check_info), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        "eviction loop detected - fix workflow code before restarting"
+    )
 
 
 def test_db_relation(context, state, temporal_worker_container):


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Brings these commits into the 2.0 branch:

* fix: pin kubernetes<36 to avoid v36.0.0 auth regression (https://github.com/canonical/temporal-worker-k8s-operator/pull/102)
* ci(terraform apply): use retry and use registry v2 instead of 2.7 (https://github.com/canonical/temporal-worker-k8s-operator/pull/109)
* [WF-190] fix: detect service crash/restart loops in update-status (https://github.com/canonical/temporal-worker-k8s-operator/pull/105)
* feat(charm): add pebble check for eviction loops (https://github.com/canonical/temporal-worker-k8s-operator/pull/110)

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

No testing required, this is just a forward port

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

This must be a merge commit to keep history, do not squash.


---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated


[WF-190]: https://warthogs.atlassian.net/browse/WF-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ